### PR TITLE
Revert "added /documentTag/bulk endpoint and removed unnecessary endp…

### DIFF
--- a/backend/src/api/endpoints/document_tag.py
+++ b/backend/src/api/endpoints/document_tag.py
@@ -25,18 +25,30 @@ async def create_new_doc_tag(*,
     return DocumentTagRead.from_orm(db_obj)
 
 
-@router.patch("/bulk/", tags=tags,
+@router.patch("/bulk/link", tags=tags,
               response_model=int,
-              summary="Applies DocumentTags to the SourceDocuments",
-              description="Adds and removes DocumentTags to and from the SourceDocuments so that all SourceDocuments "
-                          "have the specified DocumentTags")
-async def bulk_tags(*,
-                    db: Session = Depends(get_db_session),
-                    multi_link: SourceDocumentDocumentTagMultiLink) -> int:
+              summary="Links multiple DocumentTags with the SourceDocuments",
+              description="Links multiple DocumentTags with the SourceDocuments and returns the number of new Links")
+async def link_multiple_tags(*,
+                             db: Session = Depends(get_db_session),
+                             multi_link: SourceDocumentDocumentTagMultiLink) -> int:
     # TODO Flo: only if the user has access?
-    return crud_document_tag.set_multiple_document_tags(db=db,
-                                                        sdoc_ids=multi_link.source_document_ids,
-                                                        tag_ids=multi_link.document_tag_ids)
+    return crud_document_tag.link_multiple_document_tags(db=db,
+                                                         sdoc_ids=multi_link.source_document_ids,
+                                                         tag_ids=multi_link.document_tag_ids)
+
+
+@router.delete("/bulk/unlink", tags=tags,
+               response_model=int,
+               summary="Unlinks all DocumentTags with the SourceDocuments",
+               description="Unlinks all DocumentTags with the SourceDocuments and returns the number of removed Links.")
+async def unlink_multiple_tags(*,
+                               db: Session = Depends(get_db_session),
+                               multi_link: SourceDocumentDocumentTagMultiLink) -> int:
+    # TODO Flo: only if the user has access?
+    return crud_document_tag.unlink_multiple_document_tags(db=db,
+                                                           sdoc_ids=multi_link.source_document_ids,
+                                                           tag_ids=multi_link.document_tag_ids)
 
 
 @router.get("/{tag_id}", tags=tags,

--- a/backend/src/app/core/data/crud/crud_base.py
+++ b/backend/src/app/core/data/crud/crud_base.py
@@ -38,9 +38,6 @@ class CRUDBase(Generic[ORMModelType, CreateDTOType, UpdateDTOType]):
     def read_multi(self, db: Session, *, skip: int = 0, limit: int = 100) -> List[ORMModelType]:
         return db.query(self.model).offset(skip).limit(limit).all()
 
-    def read_by_ids(self, db: Session, ids: List[int]) -> List[ORMModelType]:
-        return db.query(self.model).filter(self.model.id.in_(ids)).all()
-
     def exists(self, db: Session, *, id: int, raise_error: bool = False) -> Optional[bool]:
         exists = db.query(self.model.id).filter(self.model.id == id).first() is not None
         if not exists and raise_error:


### PR DESCRIPTION
…oints for bulk linking and unlinking DocumentTags"

This reverts commit 54a195e8417c5d003ba54207b50c89a55453f7bd.

This commit was wrongly added to this repository. /bulk/link and /bulk/unlink are necessary to achieve the wanted behaviour in the frontend.