### PR TITLE
Anno fix

### DIFF
--- a/backend/src/api/endpoints/bbox_annotation.py
+++ b/backend/src/api/endpoints/bbox_annotation.py
@@ -40,6 +40,9 @@ def add_bbox_annotation(
     resolve_code: bool = Depends(resolve_code_param),
     authz_user: AuthzUser = Depends(),
 ) -> Union[BBoxAnnotationRead, BBoxAnnotationReadResolvedCode]:
+    authz_user.assert_object_has_same_user_id(
+        Crud.ANNOTATION_DOCUMENT, bbox.annotation_document_id
+    )
     authz_user.assert_in_same_project_as(
         Crud.ANNOTATION_DOCUMENT, bbox.annotation_document_id
     )

--- a/backend/src/api/endpoints/span_annotation.py
+++ b/backend/src/api/endpoints/span_annotation.py
@@ -38,6 +38,9 @@ def add_span_annotation(
     authz_user: AuthzUser = Depends(),
     validate: Validate = Depends(),
 ) -> Union[SpanAnnotationRead, SpanAnnotationReadResolved]:
+    authz_user.assert_object_has_same_user_id(
+        Crud.ANNOTATION_DOCUMENT, span.annotation_document_id
+    )
     authz_user.assert_in_same_project_as(Crud.CODE, span.code_id)
     authz_user.assert_in_same_project_as(
         Crud.ANNOTATION_DOCUMENT, span.annotation_document_id


### PR DESCRIPTION
Fixes authentification for bbox and span annotation. Now checks if both have the same user_id. Fixes Issue #362 