### PR TITLE
fix file content auth

### DIFF
--- a/backend/src/api/endpoints/authentication.py
+++ b/backend/src/api/endpoints/authentication.py
@@ -1,11 +1,10 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
-from starlette.datastructures import MutableHeaders
 
-from api.dependencies import get_current_user, get_db_session, reusable_oauth2_scheme
+from api.dependencies import get_current_user, get_db_session
 from api.util import credentials_exception
 from app.core.authorization.authz_user import AuthzUser
 from app.core.data.crud.crud_base import NoSuchElementError
@@ -20,6 +19,9 @@ from app.core.data.dto.user import (
 )
 from app.core.mail.mail_service import MailService
 from app.core.security import generate_jwt
+
+CONTENT_PREFIX = "/content/projects/"
+AUTHORIZATION = "Authorization"
 
 router = APIRouter(prefix="/authentication", tags=["authentication"])
 
@@ -60,6 +62,7 @@ def login(
     *,
     db: Session = Depends(get_db_session),
     user_login_form_data: OAuth2PasswordRequestForm = Depends(),
+    response: Response,
 ) -> UserAuthorizationHeaderData:
     user_login = UserLogin(
         username=user_login_form_data.username,
@@ -71,6 +74,15 @@ def login(
 
     (access_token, access_token_expires) = generate_jwt(user)
     refresh_token = crud_refresh_token.generate(db, user.id)
+
+    response.set_cookie(
+        AUTHORIZATION,
+        access_token,
+        expires=access_token_expires,
+        secure=True,
+        httponly=True,
+        samesite="strict",
+    )
 
     return UserAuthorizationHeaderData(
         access_token=access_token,
@@ -86,10 +98,14 @@ def login(
     summary="Revokes the refresh token associated with the given session.",
 )
 def logout(
-    *, db: Session = Depends(get_db_session), dto: RefreshAccessTokenData = Depends()
+    *,
+    db: Session = Depends(get_db_session),
+    dto: RefreshAccessTokenData = Depends(),
+    response: Response,
 ):
     token = crud_refresh_token.read_and_verify(db, dto.refresh_token)
     crud_refresh_token.revoke(db, token)
+    response.delete_cookie(AUTHORIZATION, secure=True, httponly=True, samesite="strict")
 
 
 @router.post(
@@ -123,27 +139,12 @@ async def auth_content(
     request: Request,
     db: Session = Depends(get_db_session),
     x_original_uri: Annotated[str | None, Header()] = None,
-) -> str:
-    
-    prefix = "/content/projects/"
-    
-    if not x_original_uri.startswith(prefix):
+):
+    if not x_original_uri.startswith(CONTENT_PREFIX):
         raise ValueError()
-    
-    index = x_original_uri.find("/", len(prefix))
 
-    project = int(x_original_uri[len(prefix):index])
-    
-    token = request.cookies["Authorization"]
-    
-    new_header = MutableHeaders(request._headers)
-    new_header["Authorization"] = token
-    request._headers = new_header
-    request.scope.update(headers=request.headers.raw)
-
-    tok = await reusable_oauth2_scheme(request)
-
-    a = AuthzUser(request, get_current_user(db, tok), db)
-
+    index = x_original_uri.find("/", len(CONTENT_PREFIX))
+    project = int(x_original_uri[len(CONTENT_PREFIX) : index])
+    token = request.cookies[AUTHORIZATION]
+    a = AuthzUser(request, get_current_user(db, token), db)
     a.assert_in_project(project)
-

--- a/backend/src/api/endpoints/authentication.py
+++ b/backend/src/api/endpoints/authentication.py
@@ -102,7 +102,7 @@ def logout(
     db: Session = Depends(get_db_session),
     dto: RefreshAccessTokenData = Depends(),
     response: Response,
-):
+) -> None:
     token = crud_refresh_token.read_and_verify(db, dto.refresh_token)
     crud_refresh_token.revoke(db, token)
     response.delete_cookie(AUTHORIZATION, secure=True, httponly=True, samesite="strict")
@@ -139,7 +139,8 @@ async def auth_content(
     request: Request,
     db: Session = Depends(get_db_session),
     x_original_uri: Annotated[str | None, Header()] = None,
-):
+) -> None:
+    # returns None on purpose
     token = request.cookies[AUTHORIZATION]
     a = AuthzUser(request, get_current_user(db, token), db)
     if not x_original_uri.startswith(CONTENT_PREFIX):

--- a/backend/src/api/endpoints/authentication.py
+++ b/backend/src/api/endpoints/authentication.py
@@ -140,11 +140,11 @@ async def auth_content(
     db: Session = Depends(get_db_session),
     x_original_uri: Annotated[str | None, Header()] = None,
 ):
+    token = request.cookies[AUTHORIZATION]
+    a = AuthzUser(request, get_current_user(db, token), db)
     if not x_original_uri.startswith(CONTENT_PREFIX):
-        raise ValueError()
+        return
 
     index = x_original_uri.find("/", len(CONTENT_PREFIX))
     project = int(x_original_uri[len(CONTENT_PREFIX) : index])
-    token = request.cookies[AUTHORIZATION]
-    a = AuthzUser(request, get_current_user(db, token), db)
     a.assert_in_project(project)

--- a/backend/src/test/api/endpoints/test_authentication.py
+++ b/backend/src/test/api/endpoints/test_authentication.py
@@ -18,6 +18,7 @@ def test_authentication_required():
         # This route requires authentication, but does so
         # in a manner we couldn't easily verify in the test.
         ({"GET"}, "/user/me"),
+        ({"GET"}, "/authentication/content"),
         # FastAPI built-in routes
         ({"GET", "HEAD"}, "/openapi.json"),
         ({"GET", "HEAD"}, "/docs"),

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -2,6 +2,7 @@ COMPOSE_PROJECT_NAME=demo
 # If you're running the backend and frontend
 # outside of containers,
 # remove their profiles to disable their containers
+# add `dev_frontend` if you run the frontend externally
 COMPOSE_PROFILES=backend,frontend,background,ray
 
 # Which user and group to use for running processes
@@ -123,7 +124,7 @@ SYSTEM_USER_PASSWORD="12SYSTEM34"
 
 FRONTEND_EXPOSED=3000
 API_EXPOSED=13120
-CONTENT_SERVER_EXPOSED=13121
+CONTENT_SERVER_EXPOSED=13121 # only required for frontend development
 
 POSTGRES_EXPOSED=13122
 RABBIT_EXPOSED=13123

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -107,6 +107,8 @@ services:
     tty: true
     networks:
       - dats_demo_network
+    profiles:
+      - dev_frontend
 
   celery-background-jobs-worker:
     image: uhhlt/dats_backend:${DATS_BACKEND_DOCKER_VERSION:-debian_dev_latest}
@@ -205,8 +207,8 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              device_ids: ["0"]
-              capabilities: [gpu]
+              device_ids: [ "0" ]
+              capabilities: [ gpu ]
     profiles:
       - ray
 
@@ -262,7 +264,6 @@ services:
       - ./backend_repo:${SHARED_REPO_ROOT:-/tmp/dats}
     depends_on:
       - elasticsearch
-      - lighttpd
       - postgres
       - rabbitmq
       - redis
@@ -289,6 +290,7 @@ services:
     image: uhhlt/dats_frontend:${DATS_FRONTEND_DOCKER_VERSION:-latest}
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./backend_repo:/usr/share/nginx/content:ro
     depends_on:
       - dats-backend-api
     ports:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -12,11 +12,6 @@ http {
         server dats-backend-api:5500;
     }
 
-    upstream docker-dats-content {
-        # this port and name has to match the service name and service port of the dats-backend
-        server lighttpd:80;
-    }
-
     server {
 
         # this port has to match the ports defined in the docker-compose file!
@@ -29,7 +24,10 @@ http {
         }
 
         location /content/ {
-            proxy_pass http://docker-dats-content/;
+            root /usr/share/nginx;
+            auth_request     /auth;
+            auth_request_set $auth_status $upstream_status;
+
         }
 
         location / {
@@ -37,6 +35,15 @@ http {
             index  index.html index.htm;
             try_files $uri /index.html;
         }
+
+        location = /auth {
+            internal;
+            proxy_pass              http://docker-dats-backend/authentication/content;
+            proxy_pass_request_body off;
+            proxy_set_header        Content-Length "";
+            proxy_set_header        X-Original-URI $request_uri;
+        }
+
 
         error_page   500 502 503 504  /50x.html;
 

--- a/frontend/src/api/openapi/services/AuthenticationService.ts
+++ b/frontend/src/api/openapi/services/AuthenticationService.ts
@@ -84,4 +84,21 @@ export class AuthenticationService {
       },
     });
   }
+  /**
+   * Returns success if the user can access the content
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static authContent({ xOriginalUri }: { xOriginalUri?: string | null }): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/authentication/content",
+      headers: {
+        "x-original-uri": xOriginalUri,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
 }


### PR DESCRIPTION
solves a critical security issue that file assets could be accessed freely by anyone.

now, project-specific files can only be accessed by users belonging to the project

implementation:

- store JWT in secure cookie on login
- cookie data is send automatically by browser for every request (includes images, file downloads)
- added nginx plugin to guard "/content" path -> make request to backend to verify if access is allowed
- added new API endpoint in `authentication.py` for the nginx check: extracts the JWT from cookie and checks with `AuthzUser` 
- remove lighttpd for prod deployments, directly serve files from nginx. (keep lighttpd for frotnend dev)

TODO in follow-up PR: rework temp directory to be under "project/id" so that temp files such as export can be guarded by this as well