### PR TITLE
annotation scaling backend implementation

### DIFF
--- a/backend/src/api/endpoints/annoscaling.py
+++ b/backend/src/api/endpoints/annoscaling.py
@@ -5,6 +5,11 @@ from fastapi import APIRouter, Depends
 from api.dependencies import get_current_user
 from app.core.annoscaling.annoscaling_service import AnnoScalingService
 from app.core.authorization.authz_user import AuthzUser
+from app.core.data.dto.annoscaling import (
+    AnnoscalingConfirmSuggest,
+    AnnoscalingResult,
+    AnnoscalingSuggest,
+)
 
 router = APIRouter(
     prefix="/annoscaling",
@@ -22,11 +27,38 @@ ass: AnnoScalingService = AnnoScalingService()
 )
 async def suggest(
     *,
-    project_id: int,
-    code_id: int,
-    top_k: int,
+    dto: AnnoscalingSuggest,
     authz_user: AuthzUser = Depends(),
-) -> List[str]:
-    authz_user.assert_in_project(project_id)
+) -> List[AnnoscalingResult]:
+    authz_user.assert_in_project(dto.project_id)
 
-    return ass.suggest(project_id, [authz_user.user.id], code_id, top_k)
+    result = ass.suggest(
+        dto.project_id, [authz_user.user.id], dto.code_id, dto.reject_cide_id, dto.top_k
+    )
+
+    return [
+        AnnoscalingResult(sdoc_id=sdoc, sentence_id=sent, text=text)
+        for sdoc, sent, text in result
+    ]
+
+
+@router.post(
+    "/confirm_suggestions",
+    summary="Suggest annotations",
+    description="Suggest annotations",
+)
+async def confirm_suggestions(
+    *,
+    dto: AnnoscalingConfirmSuggest,
+    authz_user: AuthzUser = Depends(),
+) -> None:
+    authz_user.assert_in_project(dto.project_id)
+
+    ass.confirm_suggestions(
+        dto.project_id,
+        authz_user.user.id,
+        dto.code_id,
+        dto.reject_code_id,
+        accept=[(a.sdoc_id, a.sentence) for a in dto.accept],
+        reject=[(r.sdoc_id, r.sentence) for r in dto.reject],
+    )

--- a/backend/src/app/core/annoscaling/annoscaling_service.py
+++ b/backend/src/app/core/annoscaling/annoscaling_service.py
@@ -3,8 +3,9 @@ from typing import Dict, Iterable, List, Tuple
 
 import numpy as np
 
+from app.core.data.crud.span_annotation import crud_span_anno
+from app.core.data.dto.span_annotation import SpanAnnotationCreate
 from app.core.data.orm.annotation_document import AnnotationDocumentORM
-from app.core.data.orm.code import CodeORM
 from app.core.data.orm.source_document import SourceDocumentORM
 from app.core.data.orm.source_document_data import SourceDocumentDataORM
 from app.core.data.orm.span_annotation import SpanAnnotationORM
@@ -19,85 +20,152 @@ class AnnoScalingService(metaclass=SingletonMeta):
     def __new__(cls, *args, **kwargs):
         cls.sqls = SQLService()
         cls.sim = SimSearchService()
-        # cls.ts = TypesenseService()
 
         return super(AnnoScalingService, cls).__new__(cls)
+
+    def confirm_suggestions(
+        self,
+        project_id: int,
+        user_id: int,
+        code_id: int,
+        reject_code_id: int,
+        accept: List[Tuple[int, int]],
+        reject: List[Tuple[int, int]],
+    ):
+        sdoc_ids = {sdoc for sdoc, _ in accept + reject}
+
+        with self.sqls.db_session() as db:
+            sdocs = (
+                db.query(SourceDocumentDataORM)
+                .filter(SourceDocumentDataORM.id.in_(sdoc_ids))
+                .all()
+            )
+            sdocs = {sdoc.id: sdoc for sdoc in sdocs}
+
+            to_create = []
+
+            for sdoc_id, sent in accept:
+                sdoc = sdocs[sdoc_id]
+                begin_char = sdoc.sentence_starts[sent]
+                end_char = sdoc.sentence_ends[sent]
+                span_anno = SpanAnnotationCreate(
+                    code_id=code_id,
+                    sdoc_id=sdoc_id,
+                    begin=begin_char,
+                    end=end_char,
+                    begin_token=sdoc.sentence_token_starts[sent],
+                    end_token=sdoc.sentence_token_ends[sent],
+                    span_text=sdoc.content[begin_char:end_char],
+                )
+                to_create.append(span_anno)
+
+            for sdoc_id, sent in reject:
+                sdoc = sdocs[sdoc_id]
+                begin_char = sdoc.sentence_starts[sent]
+                end_char = sdoc.sentence_ends[sent]
+                span_anno = SpanAnnotationCreate(
+                    code_id=reject_code_id,
+                    sdoc_id=sdoc_id,
+                    begin=begin_char,
+                    end=end_char,
+                    begin_token=sdoc.sentence_token_starts[sent],
+                    end_token=sdoc.sentence_token_ends[sent],
+                    span_text=sdoc.content[begin_char:end_char],
+                )
+                to_create.append(span_anno)
+
+            crud_span_anno.create_bulk(db, user_id=user_id, create_dtos=to_create)
 
     def suggest(
         self,
         project_id: int,
         user_ids: List[int],
         code_id: int,
+        reject_code_id: int,
         top_k: int,
-    ) -> List[str]:
+    ) -> List[Tuple[int, int, str]]:
         start_time = perf_counter_ns()
         # takes 4ms (small project)
         occurrences = self.__get_annotations(project_id, user_ids, code_id)
+        rejections = self.__get_annotations(project_id, user_ids, reject_code_id)
         end_time = perf_counter_ns()
         print("it took", end_time - start_time, "ns to get annotations from the DB")
 
         start_time = perf_counter_ns()
         # takes 2ms (small project)
-        sdoc_sentences = self.__get_sentences({id for _, _, id in occurrences})
+        sdoc_sentences = self.__get_sentences(
+            {id for _, _, id in occurrences + rejections}
+        )
         end_time = perf_counter_ns()
         print("it took", end_time - start_time, "ns to get sentences from the DB")
 
-        sdoc_sent_ids = []
-
         start_time = perf_counter_ns()
-        # takes around 0.1ms per annotation
-        for start, end, sdoc_id in occurrences:
-            # TODO loops are bad, need a much faster way to link annotations to sentences
-            # best: do everything in DB and only return sentence ID per annotation
-            # alternative: load all from DB (in chunks?) and compute via numpy
-            starts, ends, _ = sdoc_sentences[sdoc_id]
-            sent_match = self.__best_match(starts, ends, start, end)
-            sdoc_sent_ids.append((sdoc_id, sent_match))
+        pos_sdoc_sent_ids = self.__get_sdoc_sent_ids(occurrences, sdoc_sentences)
+        neg_sdoc_sent_ids = self.__get_sdoc_sent_ids(rejections, sdoc_sentences)
+
         end_time = perf_counter_ns()
         print("it took", end_time - start_time, "ns to match annotations to sentences")
         start_time = perf_counter_ns()
         # takes around 20ms per object. so, 50 annotations take already 1 full second
-        hits = self.sim.suggest_similar_sentences(project_id, sdoc_sent_ids, top_k)
+        hits = self.sim.suggest_similar_sentences(
+            project_id, pos_sdoc_sent_ids, neg_sdoc_sent_ids, top_k
+        )
         end_time = perf_counter_ns()
         print(
             "it took", end_time - start_time, "ns to get similar sentences from index"
         )
         sim_doc_sentences = self.__get_sentences({hit.sdoc_id for hit in hits})
 
-        texts = []
+        results = []
         for hit in hits:
             starts, ends, content = sim_doc_sentences[hit.sdoc_id]
-            texts.append(content[starts[hit.sentence_id] : ends[hit.sentence_id]])
-        return texts
+            text = content[starts[hit.sentence_id] : ends[hit.sentence_id]]
+            results.append((hit.sdoc_id, hit.sentence_id, text))
+        return results
 
-    def __get_annotations(self, project_id: int, user_ids: List[int], code_id: int):
+    def __get_sdoc_sent_ids(
+        self,
+        spans: List[Tuple[int, int, int]],
+        sdoc_sentences: Dict[int, Tuple[List[int], List[int], str]],
+    ) -> List[Tuple[int, int]]:
+        sdoc_sent_ids = []
+        # takes around 0.1ms per annotation
+        for start, end, sdoc_id in spans:
+            # TODO loops are bad, need a much faster way to link annotations to sentences
+            # best: do everything in DB and only return sentence ID per annotation
+            # alternative: load all from DB (in chunks?) and compute via numpy
+            starts, ends, _ = sdoc_sentences[sdoc_id]
+            sent_match = self.__best_match(starts, ends, start, end)
+            sdoc_sent_ids.append((sdoc_id, sent_match))
+        return sdoc_sent_ids
+
+    def __get_annotations(
+        self, project_id: int, user_ids: List[int], code_id: int
+    ) -> List[Tuple[int, int, int]]:
         with self.sqls.db_session() as db:
             query = (
                 db.query(
-                    SpanAnnotationORM,
-                    SourceDocumentORM.id,
+                    SpanAnnotationORM.begin,
+                    SpanAnnotationORM.end,
+                    AnnotationDocumentORM.source_document_id,
                 )
                 .join(
                     AnnotationDocumentORM,
-                    AnnotationDocumentORM.source_document_id == SourceDocumentORM.id,
-                )
-                .join(
-                    SpanAnnotationORM,
                     SpanAnnotationORM.annotation_document_id
                     == AnnotationDocumentORM.id,
                 )
                 .join(
-                    CodeORM,
-                    CodeORM.id == SpanAnnotationORM.code_id,
+                    SourceDocumentORM,
+                    SourceDocumentORM.id == AnnotationDocumentORM.source_document_id,
                 )
                 .filter(
                     SourceDocumentORM.project_id == project_id,
                     AnnotationDocumentORM.user_id.in_(user_ids),
-                    CodeORM.id == code_id,
+                    SpanAnnotationORM.code_id == code_id,
                 )
             )
             res = query.all()
-            return [(r[0].begin, r[0].end, r[1]) for r in res]
+            return [(r[0], r[1], r[2]) for r in res]
 
     def __get_sentences(
         self, sdoc_ids: Iterable[int]
@@ -117,4 +185,11 @@ class AnnoScalingService(metaclass=SingletonMeta):
         return np.asarray(overlap).argmax().item()
 
     def __overlap(self, s1: int, e1: int, s2: int, e2: int):
+        return max(min(e1, e2) - max(s1, s2), 0)
+        return max(min(e1, e2) - max(s1, s2), 0)
+        return max(min(e1, e2) - max(s1, s2), 0)
+        return max(min(e1, e2) - max(s1, s2), 0)
+        return max(min(e1, e2) - max(s1, s2), 0)
+        return max(min(e1, e2) - max(s1, s2), 0)
+        return max(min(e1, e2) - max(s1, s2), 0)
         return max(min(e1, e2) - max(s1, s2), 0)

--- a/backend/src/app/core/data/dto/annoscaling.py
+++ b/backend/src/app/core/data/dto/annoscaling.py
@@ -1,0 +1,33 @@
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class AnnoscalingSuggest(BaseModel):
+    project_id: int = Field(description="Project to retrieve suggestions")
+    code_id: int = Field(description="Code to provide suggestions for")
+    reject_cide_id: int = Field(description="Code to use as opposing code")
+    top_k: int = Field(description="Number of suggestions to provide")
+
+
+class SdocSentencePair(BaseModel):
+    sdoc_id: int = Field()
+    sentence: int = Field()
+
+
+class AnnoscalingConfirmSuggest(BaseModel):
+    project_id: int = Field(description="Project to apply suggestions")
+    code_id: int = Field(description="Code to apply on accepted spans")
+    reject_code_id: int = Field(description="Code to apply on rejected spans")
+    accept: List[SdocSentencePair] = Field(
+        description="Suggested annotations to accept"
+    )
+    reject: List[SdocSentencePair] = Field(
+        description="Suggested annotations to reject"
+    )
+
+
+class AnnoscalingResult(BaseModel):
+    sdoc_id: int = Field(description="ID of the source document")
+    sentence_id: int = Field(description="ID of the sentence within the document")
+    text: str = Field(description="Sentence text")

--- a/backend/src/app/core/data/orm/source_document_data.py
+++ b/backend/src/app/core/data/orm/source_document_data.py
@@ -57,3 +57,13 @@ class SourceDocumentDataORM(ORMBase):
     @property
     def sentence_character_offsets(self):
         return [(s, e) for s, e in zip(self.sentence_starts, self.sentence_ends)]
+
+    @property
+    def sentence_token_starts(self):
+        char2tok = {c: i for i, c in enumerate(self.token_starts)}
+        return [char2tok[s] for s in self.sentence_starts]
+
+    @property
+    def sentence_token_ends(self):
+        char2tok = {c: i for i, c in enumerate(self.token_ends)}
+        return [char2tok[e] for e in self.sentence_ends]

--- a/backend/src/app/core/db/vector_index_service.py
+++ b/backend/src/app/core/db/vector_index_service.py
@@ -45,6 +45,7 @@ class VectorIndexService(ABC, metaclass=SingletonMeta):
         index_type: IndexType,
         proj_id: int,
         sdoc_sent_ids: List[Tuple[int, int]],
+        top_k: int,
     ) -> List[SimSearchSentenceHit]:
         pass
 

--- a/backend/src/app/core/db/weaviate_service.py
+++ b/backend/src/app/core/db/weaviate_service.py
@@ -383,6 +383,7 @@ class WeaviateService(VectorIndexService):
         index_type: IndexType,
         proj_id: int,
         sdoc_sent_ids: List[Tuple[int, int]],
+        top_k: int,
     ) -> List[SimSearchSentenceHit]:
         obj_ids = [
             # TODO weaviate does not support batch/bulk queries.
@@ -412,7 +413,7 @@ class WeaviateService(VectorIndexService):
                 # query.with_near_object({"id": obj, "certainty": threshold})
                 .with_additional(["certainty"])
                 .with_where(project_filter)
-                .with_limit(10)
+                .with_limit(top_k)
             )
 
             res = query.do()["data"]["Get"][self._sentence_class_name]

--- a/frontend/src/api/openapi/models/AnnoscalingConfirmSuggest.ts
+++ b/frontend/src/api/openapi/models/AnnoscalingConfirmSuggest.ts
@@ -1,0 +1,27 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { SdocSentencePair } from "./SdocSentencePair";
+export type AnnoscalingConfirmSuggest = {
+  /**
+   * Project to apply suggestions
+   */
+  project_id: number;
+  /**
+   * Code to apply on accepted spans
+   */
+  code_id: number;
+  /**
+   * Code to apply on rejected spans
+   */
+  reject_code_id: number;
+  /**
+   * Suggested annotations to accept
+   */
+  accept: Array<SdocSentencePair>;
+  /**
+   * Suggested annotations to reject
+   */
+  reject: Array<SdocSentencePair>;
+};

--- a/frontend/src/api/openapi/models/AnnoscalingResult.ts
+++ b/frontend/src/api/openapi/models/AnnoscalingResult.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AnnoscalingResult = {
+  /**
+   * ID of the source document
+   */
+  sdoc_id: number;
+  /**
+   * ID of the sentence within the document
+   */
+  sentence_id: number;
+  /**
+   * Sentence text
+   */
+  text: string;
+};

--- a/frontend/src/api/openapi/models/AnnoscalingSuggest.ts
+++ b/frontend/src/api/openapi/models/AnnoscalingSuggest.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AnnoscalingSuggest = {
+  /**
+   * Project to retrieve suggestions
+   */
+  project_id: number;
+  /**
+   * Code to provide suggestions for
+   */
+  code_id: number;
+  /**
+   * Code to use as opposing code
+   */
+  reject_cide_id: number;
+  /**
+   * Number of suggestions to provide
+   */
+  top_k: number;
+};

--- a/frontend/src/api/openapi/models/SdocSentencePair.ts
+++ b/frontend/src/api/openapi/models/SdocSentencePair.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SdocSentencePair = {
+  sdoc_id: number;
+  sentence: number;
+};

--- a/frontend/src/api/openapi/services/AnnoscalingService.ts
+++ b/frontend/src/api/openapi/services/AnnoscalingService.ts
@@ -2,6 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AnnoscalingConfirmSuggest } from "../models/AnnoscalingConfirmSuggest";
+import type { AnnoscalingResult } from "../models/AnnoscalingResult";
+import type { AnnoscalingSuggest } from "../models/AnnoscalingSuggest";
 import type { CancelablePromise } from "../core/CancelablePromise";
 import { OpenAPI } from "../core/OpenAPI";
 import { request as __request } from "../core/request";
@@ -9,26 +12,40 @@ export class AnnoscalingService {
   /**
    * Suggest annotations
    * Suggest annotations
-   * @returns string Successful Response
+   * @returns AnnoscalingResult Successful Response
    * @throws ApiError
    */
   public static suggest({
-    projectId,
-    codeId,
-    topK,
+    requestBody,
   }: {
-    projectId: number;
-    codeId: number;
-    topK: number;
-  }): CancelablePromise<Array<string>> {
+    requestBody: AnnoscalingSuggest;
+  }): CancelablePromise<Array<AnnoscalingResult>> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/annoscaling/suggest",
-      query: {
-        project_id: projectId,
-        code_id: codeId,
-        top_k: topK,
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
       },
+    });
+  }
+  /**
+   * Suggest annotations
+   * Suggest annotations
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static confirmSuggestions({
+    requestBody,
+  }: {
+    requestBody: AnnoscalingConfirmSuggest;
+  }): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/annoscaling/confirm_suggestions",
+      body: requestBody,
+      mediaType: "application/json",
       errors: {
         422: `Validation Error`,
       },

--- a/frontend/src/openapi.json
+++ b/frontend/src/openapi.json
@@ -4610,23 +4610,20 @@
         "summary": "Suggest annotations",
         "description": "Suggest annotations",
         "operationId": "suggest",
-        "security": [{ "OAuth2PasswordBearer": [] }],
-        "parameters": [
-          {
-            "name": "project_id",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "integer", "title": "Project Id" }
-          },
-          { "name": "code_id", "in": "query", "required": true, "schema": { "type": "integer", "title": "Code Id" } },
-          { "name": "top_k", "in": "query", "required": true, "schema": { "type": "integer", "title": "Top K" } }
-        ],
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AnnoscalingSuggest" } } },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "type": "array", "items": { "type": "string" }, "title": "Response Annoscaling-Suggest" }
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AnnoscalingResult" },
+                  "type": "array",
+                  "title": "Response Annoscaling-Suggest"
+                }
               }
             }
           },
@@ -4634,7 +4631,28 @@
             "description": "Validation Error",
             "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HTTPValidationError" } } }
           }
-        }
+        },
+        "security": [{ "OAuth2PasswordBearer": [] }]
+      }
+    },
+    "/annoscaling/confirm_suggestions": {
+      "post": {
+        "tags": ["annoscaling"],
+        "summary": "Suggest annotations",
+        "description": "Suggest annotations",
+        "operationId": "confirm_suggestions",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AnnoscalingConfirmSuggest" } } },
+          "required": true
+        },
+        "responses": {
+          "200": { "description": "Successful Response", "content": { "application/json": { "schema": {} } } },
+          "422": {
+            "description": "Validation Error",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HTTPValidationError" } } }
+          }
+        },
+        "security": [{ "OAuth2PasswordBearer": [] }]
       }
     },
     "/whiteboard": {
@@ -5780,6 +5798,61 @@
         },
         "type": "object",
         "title": "AnalysisTableUpdate"
+      },
+      "AnnoscalingConfirmSuggest": {
+        "properties": {
+          "project_id": { "type": "integer", "title": "Project Id", "description": "Project to apply suggestions" },
+          "code_id": { "type": "integer", "title": "Code Id", "description": "Code to apply on accepted spans" },
+          "reject_code_id": {
+            "type": "integer",
+            "title": "Reject Code Id",
+            "description": "Code to apply on rejected spans"
+          },
+          "accept": {
+            "items": { "$ref": "#/components/schemas/SdocSentencePair" },
+            "type": "array",
+            "title": "Accept",
+            "description": "Suggested annotations to accept"
+          },
+          "reject": {
+            "items": { "$ref": "#/components/schemas/SdocSentencePair" },
+            "type": "array",
+            "title": "Reject",
+            "description": "Suggested annotations to reject"
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "code_id", "reject_code_id", "accept", "reject"],
+        "title": "AnnoscalingConfirmSuggest"
+      },
+      "AnnoscalingResult": {
+        "properties": {
+          "sdoc_id": { "type": "integer", "title": "Sdoc Id", "description": "ID of the source document" },
+          "sentence_id": {
+            "type": "integer",
+            "title": "Sentence Id",
+            "description": "ID of the sentence within the document"
+          },
+          "text": { "type": "string", "title": "Text", "description": "Sentence text" }
+        },
+        "type": "object",
+        "required": ["sdoc_id", "sentence_id", "text"],
+        "title": "AnnoscalingResult"
+      },
+      "AnnoscalingSuggest": {
+        "properties": {
+          "project_id": { "type": "integer", "title": "Project Id", "description": "Project to retrieve suggestions" },
+          "code_id": { "type": "integer", "title": "Code Id", "description": "Code to provide suggestions for" },
+          "reject_cide_id": {
+            "type": "integer",
+            "title": "Reject Cide Id",
+            "description": "Code to use as opposing code"
+          },
+          "top_k": { "type": "integer", "title": "Top K", "description": "Number of suggestions to provide" }
+        },
+        "type": "object",
+        "required": ["project_id", "code_id", "reject_cide_id", "top_k"],
+        "title": "AnnoscalingSuggest"
       },
       "AnnotatedImageResult": {
         "properties": {
@@ -8124,6 +8197,15 @@
           "SD_SPAN_ANNOTATIONS"
         ],
         "title": "SdocColumns"
+      },
+      "SdocSentencePair": {
+        "properties": {
+          "sdoc_id": { "type": "integer", "title": "Sdoc Id" },
+          "sentence": { "type": "integer", "title": "Sentence" }
+        },
+        "type": "object",
+        "required": ["sdoc_id", "sentence"],
+        "title": "SdocSentencePair"
       },
       "SimSearchImageHit": {
         "properties": {


### PR DESCRIPTION
this PR adds annotation scaling functionality to the backend: given a type of annotation, the system suggests more candidate sentences. this already features advanced candidate filtering by removing any already annotated sentences or the ones that a closest to a negative support set.

so far, the implementation is rather inefficient due to weaviate not supporting batch queries. for larger projects, we need to use another vector index