### PR TITLE
annotation scaling frontend v1

### DIFF
--- a/frontend/src/api/AnnoscalingHooks.ts
+++ b/frontend/src/api/AnnoscalingHooks.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import queryClient from "../plugins/ReactQueryClient.ts";
+import { AnnoscalingResult } from "./openapi/models/AnnoscalingResult.ts";
+import { AnnoscalingService } from "./openapi/services/AnnoscalingService.ts";
+import { QueryKey } from "./QueryKey.ts";
+
+const useAnnotationSuggestions = (projectId: number, codeId?: number, antiCodeId?: number) =>
+  useQuery<AnnoscalingResult[], Error>({
+    queryKey: [QueryKey.ANNOSCALING_SUGGEST, projectId, codeId, antiCodeId],
+    enabled: !!codeId && !!antiCodeId,
+    queryFn: () =>
+      AnnoscalingService.suggest({
+        requestBody: { code_id: codeId!, project_id: projectId, reject_cide_id: antiCodeId!, top_k: 10 },
+      }),
+  });
+
+const useConfirmSuggestions = () =>
+  useMutation({
+    mutationFn: AnnoscalingService.confirmSuggestions,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: [QueryKey.ANNOSCALING_SUGGEST] }),
+  });
+
+const AnnoscalingHooks = {
+  useAnnotationSuggestions,
+  useConfirmSuggestions,
+};
+
+export default AnnoscalingHooks;

--- a/frontend/src/api/QueryKey.ts
+++ b/frontend/src/api/QueryKey.ts
@@ -136,6 +136,8 @@ export const QueryKey = {
   ANALYSIS_CODE_OCCURRENCES: "analysisCodeOccurrences",
   ANALYSIS_ANNOTATION_OCCURRENCES: "analysisAnnotationOccurrences",
 
+  ANNOSCALING_SUGGEST: "annoscalingSuggest",
+
   // preprocessing status of the project (by project id)
   PREPRO_PROJECT_STATUS: "preproProjectStatus",
 

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -9,6 +9,7 @@ import Login from "../views/Login.tsx";
 import NotFound from "../views/NotFound.tsx";
 import Analysis from "../views/analysis/Analysis.tsx";
 import AnnotatedSegments from "../views/analysis/AnnotatedSegments/AnnotatedSegments.tsx";
+import AnnotationScaling from "../views/analysis/AnnotationScaling/AnnotationScaling.tsx";
 import CodeFrequencyAnalysis from "../views/analysis/CodeFrequency/CodeFrequencyAnalysis.tsx";
 import CotaDashboard from "../views/analysis/ConceptsOverTime/CotaDashboard.tsx";
 import CotaView from "../views/analysis/ConceptsOverTime/CotaView.tsx";
@@ -165,7 +166,10 @@ const router = createBrowserRouter([
         path: "/project/:projectId/analysis/concepts-over-time-analysis/:cotaId",
         element: <CotaView />,
       },
-
+      {
+        path: "/project/:projectId/analysis/annotation-scaling",
+        element: <AnnotationScaling />,
+      },
       {
         path: "/project/:projectId/whiteboard",
         element: <WhiteboardDashboard />,

--- a/frontend/src/views/analysis/Analysis.tsx
+++ b/frontend/src/views/analysis/Analysis.tsx
@@ -51,6 +51,13 @@ function Analysis() {
           color={"#77dd77"}
         />
 
+        <AnalysisCard
+          to={"annotation-scaling"}
+          title={"Annotation Scaling"}
+          description={"Semi-automatically scale annotations"}
+          color={"#77dd77"}
+        />
+
         <AnalysisCard to={"table"} title={"Table"} description={"Analyse with tables."} color={"#77dd77"} />
       </Box>
     </NoSidebarLayout>

--- a/frontend/src/views/analysis/AnnotationScaling/AnnotationScaling.tsx
+++ b/frontend/src/views/analysis/AnnotationScaling/AnnotationScaling.tsx
@@ -29,12 +29,12 @@ function AnnotationScaling() {
   const codes = ProjectHooks.useGetAllCodes(projectId, false);
 
   const [code, setCode] = useState<CodeRead | null>(null);
-  const [antiCode, setAntiCode] = useState<CodeRead | null>(null);
+  const [opposingCode, setopposingCode] = useState<CodeRead | null>(null);
   const [accept, setAccept] = useState<AnnoscalingResult[]>([]);
   const [reject, setReject] = useState<AnnoscalingResult[]>([]);
 
   // global server state (react-query)
-  const suggestions = AnnoscalingHooks.useAnnotationSuggestions(projectId, code?.id, antiCode?.id);
+  const suggestions = AnnoscalingHooks.useAnnotationSuggestions(projectId, code?.id, opposingCode?.id);
   const confirmHook = AnnoscalingHooks.useConfirmSuggestions();
 
   const handleSubmit = () => {
@@ -42,7 +42,7 @@ function AnnotationScaling() {
       {
         requestBody: {
           code_id: code!.id,
-          reject_code_id: antiCode!.id,
+          reject_code_id: opposingCode!.id,
           project_id: projectId,
           accept: accept.map((r) => ({ sdoc_id: r.sdoc_id, sentence: r.sentence_id })),
           reject: reject.map((r) => ({ sdoc_id: r.sdoc_id, sentence: r.sentence_id })),
@@ -102,15 +102,15 @@ function AnnotationScaling() {
             sx={{ width: 300 }}
             renderInput={(params) => (
               <Stack direction="row" alignItems="center">
-                <SquareIcon style={{ color: antiCode?.color ?? "white" }}></SquareIcon>
-                <TextField autoFocus {...params} label="Anti-Code"></TextField>
+                <SquareIcon style={{ color: opposingCode?.color ?? "white" }}></SquareIcon>
+                <TextField autoFocus {...params} label="Opposing-Code"></TextField>
               </Stack>
             )}
             autoHighlight
             selectOnFocus
             clearOnBlur
             handleHomeEndKeys
-            onChange={(_event, value, _reason) => setAntiCode(value)}
+            onChange={(_event, value, _reason) => setopposingCode(value)}
           />
           <Button
             variant="contained"

--- a/frontend/src/views/analysis/AnnotationScaling/AnnotationScaling.tsx
+++ b/frontend/src/views/analysis/AnnotationScaling/AnnotationScaling.tsx
@@ -1,0 +1,150 @@
+import SquareIcon from "@mui/icons-material/Square";
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CircularProgress,
+  Portal,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useContext, useState } from "react";
+import { useParams } from "react-router-dom";
+import AnnoscalingHooks from "../../../api/AnnoscalingHooks.ts";
+import { AnnoscalingResult } from "../../../api/openapi/models/AnnoscalingResult.ts";
+import { CodeRead } from "../../../api/openapi/models/CodeRead.ts";
+import ProjectHooks from "../../../api/ProjectHooks.ts";
+import { AppBarContext } from "../../../layouts/TwoBarLayout.tsx";
+import AnnotationScalingList from "./AnnotationScalingList.tsx";
+
+function AnnotationScaling() {
+  const appBarContainerRef = useContext(AppBarContext);
+
+  // global client state (react router)
+  const projectId = parseInt(useParams<{ projectId: string }>().projectId!);
+  const codes = ProjectHooks.useGetAllCodes(projectId, false);
+
+  const [code, setCode] = useState<CodeRead | null>(null);
+  const [antiCode, setAntiCode] = useState<CodeRead | null>(null);
+  const [accept, setAccept] = useState<AnnoscalingResult[]>([]);
+  const [reject, setReject] = useState<AnnoscalingResult[]>([]);
+
+  // global server state (react-query)
+  const suggestions = AnnoscalingHooks.useAnnotationSuggestions(projectId, code?.id, antiCode?.id);
+  const confirmHook = AnnoscalingHooks.useConfirmSuggestions();
+
+  const handleSubmit = () => {
+    confirmHook.mutate(
+      {
+        requestBody: {
+          code_id: code!.id,
+          reject_code_id: antiCode!.id,
+          project_id: projectId,
+          accept: accept.map((r) => ({ sdoc_id: r.sdoc_id, sentence: r.sentence_id })),
+          reject: reject.map((r) => ({ sdoc_id: r.sdoc_id, sentence: r.sentence_id })),
+        },
+      },
+      {
+        onSuccess() {
+          setAccept([]);
+          setReject([]);
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <Portal container={appBarContainerRef?.current}>
+        <Typography variant="h6" component="div">
+          Annotation Scaling
+        </Typography>
+      </Portal>
+      <Card elevation={1} sx={{ margin: 1 }}>
+        <CardActions>
+          <Autocomplete
+            disablePortal
+            options={codes.data ?? []}
+            getOptionLabel={(option) => option.name}
+            renderOption={(props, option) => (
+              <li {...props} key={option.id}>
+                <Box style={{ width: 20, height: 20, backgroundColor: option.color, marginRight: 8 }}></Box>{" "}
+                {option.name}
+              </li>
+            )}
+            sx={{ width: 300 }}
+            renderInput={(params) => (
+              <Stack direction="row" alignItems="center">
+                <SquareIcon style={{ color: code?.color ?? "white" }}></SquareIcon>
+                <TextField autoFocus {...params} label="Code"></TextField>
+              </Stack>
+            )}
+            autoHighlight
+            selectOnFocus
+            clearOnBlur
+            handleHomeEndKeys
+            onChange={(_event, value, _reason) => setCode(value)}
+          />
+          <Autocomplete
+            disablePortal
+            options={codes.data ?? []}
+            getOptionLabel={(option) => option.name}
+            renderOption={(props, option) => (
+              <li {...props} key={option.id}>
+                <Box style={{ width: 20, height: 20, backgroundColor: option.color, marginRight: 8 }}></Box>{" "}
+                {option.name}
+              </li>
+            )}
+            sx={{ width: 300 }}
+            renderInput={(params) => (
+              <Stack direction="row" alignItems="center">
+                <SquareIcon style={{ color: antiCode?.color ?? "white" }}></SquareIcon>
+                <TextField autoFocus {...params} label="Anti-Code"></TextField>
+              </Stack>
+            )}
+            autoHighlight
+            selectOnFocus
+            clearOnBlur
+            handleHomeEndKeys
+            onChange={(_event, value, _reason) => setAntiCode(value)}
+          />
+          <Button
+            variant="contained"
+            disabled={accept.length === 0 && reject.length === 0}
+            onClick={(_) => handleSubmit()}
+          >
+            Confirm suggestions/rejections
+          </Button>
+        </CardActions>
+        <CardContent style={{ maxHeight: "80vh", overflow: "auto" }}>
+          {suggestions.isFetching ? (
+            <CircularProgress />
+          ) : suggestions.isSuccess ? (
+            suggestions.data.length > 0 ? (
+              <AnnotationScalingList
+                data={suggestions.data!}
+                submit={handleSubmit}
+                accept={accept}
+                reject={reject}
+                setAccept={setAccept}
+                setReject={setReject}
+              />
+            ) : (
+              <Typography>
+                It seems you have not annotated a single positive example (or all possible suggestions are exhausted)
+              </Typography>
+            )
+          ) : (
+            <Typography>Select a code and its negated counterpart to retrieve suggestions</Typography>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  );
+}
+
+export default AnnotationScaling;

--- a/frontend/src/views/analysis/AnnotationScaling/AnnotationScalingList.tsx
+++ b/frontend/src/views/analysis/AnnotationScaling/AnnotationScalingList.tsx
@@ -1,0 +1,141 @@
+import AddIcon from "@mui/icons-material/Add";
+import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import RemoveIcon from "@mui/icons-material/Remove";
+import { List, ListItem, ListItemButton, ListItemText, ToggleButton, ToggleButtonGroup } from "@mui/material";
+import { KeyboardEvent, useState } from "react";
+import { AnnoscalingResult } from "../../../api/openapi/models/AnnoscalingResult.ts";
+
+interface AnnotationScalingListContentProps {
+  data: AnnoscalingResult[];
+  submit: () => void;
+  accept: AnnoscalingResult[];
+  reject: AnnoscalingResult[];
+  setAccept: React.Dispatch<React.SetStateAction<AnnoscalingResult[]>>;
+  setReject: React.Dispatch<React.SetStateAction<AnnoscalingResult[]>>;
+}
+
+function AnnotationScalingList({
+  data,
+  submit,
+  accept,
+  reject,
+  setAccept,
+  setReject,
+}: AnnotationScalingListContentProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const suggestions = [null, ...data];
+
+  const toggle = (value: AnnoscalingResult | null, good: boolean | null) => {
+    if (value === null) {
+      // toggle all list entries
+      if (good === true) {
+        setAccept(data);
+        setReject([]);
+      } else if (good === false) {
+        setAccept([]);
+        setReject(data);
+      } else {
+        setAccept([]);
+        setReject([]);
+      }
+      return;
+    }
+    const currentAcceptIndex = accept.indexOf(value);
+    const currentRejectIndex = reject.indexOf(value);
+    const newAccept = [...accept];
+    const newReject = [...reject];
+
+    if (currentAcceptIndex === -1 && good === true) {
+      newAccept.push(value);
+    } else if (currentAcceptIndex !== -1 && good !== true) {
+      newAccept.splice(currentAcceptIndex, 1);
+    }
+
+    if (currentRejectIndex === -1 && good === false) {
+      newReject.push(value);
+    } else if (currentRejectIndex !== -1 && good !== false) {
+      newReject.splice(currentRejectIndex, 1);
+    }
+
+    setAccept(newAccept);
+    setReject(newReject);
+  };
+
+  const handleToggle = (value: AnnoscalingResult | null, good: boolean | null) => () => toggle(value, good);
+
+  const handleKeyNav = (event: KeyboardEvent) => {
+    if (event.code === "ArrowDown" && selectedIndex + 1 < suggestions.length) {
+      setSelectedIndex(selectedIndex + 1);
+    } else if (event.code === "ArrowUp" && selectedIndex > 0) {
+      setSelectedIndex(selectedIndex - 1);
+    } else if (event.code === "ArrowLeft") {
+      const val = suggestions[selectedIndex];
+      toggle(val, true);
+    } else if (event.code === "ArrowRight") {
+      const val = suggestions[selectedIndex];
+      toggle(val, false);
+    } else if (event.code === "Escape") {
+      const val = suggestions[selectedIndex];
+      toggle(val, null);
+    } else if (event.code === "Enter") {
+      submit();
+    } else {
+      return;
+    }
+    event.preventDefault();
+  };
+
+  return (
+    <List sx={{ width: "100%" }} onKeyDown={handleKeyNav} dense disablePadding>
+      {suggestions.map((value, i) => {
+        return (
+          <ListItem key={value ? `${value.sdoc_id}-${value.sentence_id}` : "all"} disablePadding divider={i === 0}>
+            <ListItemButton
+              disableRipple
+              autoFocus={i === 0}
+              role={undefined}
+              dense
+              selected={selectedIndex === i}
+              //   onClick={() => setSelectedIndex(i)}
+            >
+              <ToggleButtonGroup exclusive size="small" sx={{ marginRight: 1 }}>
+                <ToggleButton
+                  color="success"
+                  value={true}
+                  selected={value ? accept.includes(value) : accept.length === data.length}
+                  onClick={handleToggle(value, true)}
+                >
+                  <AddIcon />
+                </ToggleButton>
+                <ToggleButton
+                  color="info"
+                  selected={
+                    value
+                      ? !accept.includes(value) && !reject.includes(value)
+                      : accept.length === 0 && reject.length === 0
+                  }
+                  value={"none"}
+                  onClick={handleToggle(value, null)}
+                >
+                  <QuestionMarkIcon />
+                </ToggleButton>
+                <ToggleButton
+                  color="error"
+                  selected={value ? reject.includes(value) : reject.length === data.length}
+                  value={false}
+                  onClick={handleToggle(value, false)}
+                >
+                  <RemoveIcon />
+                </ToggleButton>
+              </ToggleButtonGroup>
+              <ListItemText primary={value ? value.text : "Select all"} />
+            </ListItemButton>
+          </ListItem>
+        );
+      })}
+    </List>
+  );
+}
+
+export default AnnotationScalingList;


### PR DESCRIPTION
this PR adds a first frontend for the annotation scaling feature: a user can retrieve sentence-level suggestions and confirm/reject (binary classification) the codes

![image](https://github.com/user-attachments/assets/c22d69be-f565-4ec6-82ea-b505b9a0813b)
