### PR TITLE
Usability improvements for tutorial 1

### DIFF
--- a/backend/src/core/code/code_dto.py
+++ b/backend/src/core/code/code_dto.py
@@ -10,7 +10,7 @@ from utils.color_utils import get_next_color
 class CodeBaseDTO(BaseModel):
     name: str = Field(description="Name of the Code")
     color: str = Field(description="Color of the Code")
-    description: str = Field(description="Description of the Code")
+    description: str = Field(description="Description of the Code", default="")
     parent_id: int | None = Field(description="Parent of the Code", default=None)
     enabled: bool = Field(
         default=True,

--- a/frontend/src/api/openapi/models/CodeCreate.ts
+++ b/frontend/src/api/openapi/models/CodeCreate.ts
@@ -14,7 +14,7 @@ export type CodeCreate = {
   /**
    * Description of the Code
    */
-  description: string;
+  description?: string;
   /**
    * Parent of the Code
    */

--- a/frontend/src/api/openapi/models/CodeRead.ts
+++ b/frontend/src/api/openapi/models/CodeRead.ts
@@ -14,7 +14,7 @@ export type CodeRead = {
   /**
    * Description of the Code
    */
-  description: string;
+  description?: string;
   /**
    * Parent of the Code
    */

--- a/frontend/src/components/Code/CodeCreateDialog.tsx
+++ b/frontend/src/components/Code/CodeCreateDialog.tsx
@@ -179,7 +179,6 @@ function CodeCreateDialog() {
           <FormTextMultiline
             name="description"
             control={control}
-            rules={{ required: "Description is required" }}
             textFieldProps={{
               label: "Description",
               error: Boolean(errors.description),

--- a/frontend/src/components/Code/CodeEditDialog.tsx
+++ b/frontend/src/components/Code/CodeEditDialog.tsx
@@ -128,6 +128,7 @@ function CodeEditDialog() {
     if (code && !code.is_system) {
       ConfirmationAPI.openConfirmationDialog({
         text: `Do you really want to delete the code "${code.name}"? This action cannot be undone!`,
+        type: "DELETE",
         onAccept: () => {
           deleteCodeMutation(
             { codeId: code.id },

--- a/frontend/src/components/Code/CodeEditDialog.tsx
+++ b/frontend/src/components/Code/CodeEditDialog.tsx
@@ -213,7 +213,6 @@ function CodeEditDialog() {
           <FormTextMultiline
             name="description"
             control={control}
-            rules={{ required: "Description is required" }}
             textFieldProps={{
               label: "Description",
               error: Boolean(errors.description),

--- a/frontend/src/components/ConfirmationDialog/ConfirmationAPI.ts
+++ b/frontend/src/components/ConfirmationDialog/ConfirmationAPI.ts
@@ -2,6 +2,7 @@ import eventBus from "../../EventBus.ts";
 
 export interface ConfirmationEvent {
   text: string;
+  type?: "DELETE" | "CONFIRM";
   onAccept: () => void;
   onReject?: () => void;
 }

--- a/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,3 +1,4 @@
+import DeleteIcon from "@mui/icons-material/Delete";
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
 import { memo, useCallback, useEffect, useState } from "react";
 import eventBus from "../../EventBus.ts";
@@ -41,6 +42,9 @@ function ConfirmationDialog() {
     if (confirmationEventData?.onAccept) confirmationEventData.onAccept();
   }, [confirmationEventData, handleClose]);
 
+  const cancelText = "Cancel";
+  const confirmText = confirmationEventData?.type == "DELETE" ? "Delete" : "Confirm";
+
   return (
     <Dialog open={dialog.isOpen} onClose={handleClose} maxWidth="sm" fullWidth>
       {confirmationEventData && (
@@ -50,9 +54,15 @@ function ConfirmationDialog() {
             <DialogContentText id="alert-dialog-description">{confirmationEventData.text}</DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleReject}>Cancel</Button>
-            <Button onClick={handleAccept} autoFocus>
-              Confirm
+            <Button onClick={handleReject}>{cancelText}</Button>
+            <Button
+              onClick={handleAccept}
+              autoFocus
+              variant="contained"
+              startIcon={confirmationEventData.type == "DELETE" ? <DeleteIcon /> : null}
+              color={confirmationEventData.type == "DELETE" ? "error" : "primary"}
+            >
+              {confirmText}
             </Button>
           </DialogActions>
         </>

--- a/frontend/src/components/Folder/FolderEditDialog.tsx
+++ b/frontend/src/components/Folder/FolderEditDialog.tsx
@@ -85,6 +85,7 @@ function FolderEditDialog() {
     if (folder) {
       ConfirmationAPI.openConfirmationDialog({
         text: `Do you really want to delete the folder "${folder.name}"? This will delete ALL contained documents, their annotations, memos, etc. This action cannot be undone!`,
+        type: "DELETE",
         onAccept: () => {
           deleteFolderMutation(
             { folderId: folder.id },

--- a/frontend/src/components/ProjectSettings/ProjectSettingsDialog.tsx
+++ b/frontend/src/components/ProjectSettings/ProjectSettingsDialog.tsx
@@ -1,17 +1,16 @@
-import DeleteIcon from "@mui/icons-material/Delete";
-import { LoadingButton, TabContext } from "@mui/lab";
+import { TabContext } from "@mui/lab";
 import TabPanel from "@mui/lab/TabPanel";
-import { AppBar, Box, Dialog, DialogActions, DialogContent, Divider, Tabs } from "@mui/material";
+import { AppBar, Dialog, DialogContent, Tabs } from "@mui/material";
 import Tab from "@mui/material/Tab";
 import React, { memo, useCallback, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import ProjectHooks from "../../api/ProjectHooks.ts";
 import { useDialogMaximize } from "../../hooks/useDialogMaximize.ts";
 import { useAppDispatch, useAppSelector } from "../../plugins/ReduxHooks.ts";
-import ConfirmationAPI from "../ConfirmationDialog/ConfirmationAPI.ts";
 import { CRUDDialogActions } from "../dialogSlice.ts";
 import DATSDialogHeader from "../MUI/DATSDialogHeader.tsx";
 import ProjectCodes from "./tabs/ProjectCodes.tsx";
+import ProjectDangerZone from "./tabs/ProjectDangerZone.tsx";
 import ProjectDetails from "./tabs/ProjectDetails.tsx";
 import ProjectImport from "./tabs/ProjectImport.tsx";
 import ProjectTags from "./tabs/ProjectTags.tsx";
@@ -36,25 +35,6 @@ function ProjectSettingsDialog() {
   const handleChangeTab = useCallback((_event: React.SyntheticEvent, newValue: string) => {
     setTab(newValue);
   }, []);
-
-  const navigate = useNavigate();
-  const { mutate: deleteProject, isPending } = ProjectHooks.useDeleteProject();
-  const handleClickRemoveProject = useCallback(() => {
-    if (project.data) {
-      ConfirmationAPI.openConfirmationDialog({
-        text: `Do you really want to delete the project "${project.data.title}"? This action cannot be undone and  will remove project and all of it's content including documents!`,
-        type: "DELETE",
-        onAccept: () => {
-          deleteProject(
-            { projId: project.data.id },
-            {
-              onSuccess: () => navigate(`/projects`),
-            },
-          );
-        },
-      });
-    }
-  }, [project.data, deleteProject, navigate]);
 
   // maximize
   const { isMaximized, toggleMaximize } = useDialogMaximize();
@@ -87,6 +67,7 @@ function ProjectSettingsDialog() {
             <Tab label="Codes" value="3" />
             <Tab label="Tags" value="4" />
             <Tab label="Import" value="5" />
+            <Tab label="Danger Zone" value="6" />
           </Tabs>
         </AppBar>
         {project.isLoading && <DialogContent>Loading project...</DialogContent>}
@@ -108,24 +89,11 @@ function ProjectSettingsDialog() {
             <TabPanel value="5" sx={{ p: 0 }} className="myFlexFillAllContainer">
               <ProjectImport project={project.data} />
             </TabPanel>
+            <TabPanel value="6" sx={{ p: 0 }} className="myFlexFillAllContainer">
+              <ProjectDangerZone project={project.data} />
+            </TabPanel>
           </React.Fragment>
         )}
-        <Divider />
-        <DialogActions>
-          <LoadingButton
-            variant="contained"
-            color="error"
-            startIcon={<DeleteIcon />}
-            sx={{ mr: 1 }}
-            onClick={handleClickRemoveProject}
-            disabled={!project.isSuccess}
-            loading={isPending}
-            loadingPosition="start"
-          >
-            Delete Project
-          </LoadingButton>
-          <Box sx={{ flexGrow: 1 }} />
-        </DialogActions>
       </TabContext>
     </Dialog>
   );

--- a/frontend/src/components/ProjectSettings/ProjectSettingsDialog.tsx
+++ b/frontend/src/components/ProjectSettings/ProjectSettingsDialog.tsx
@@ -43,6 +43,7 @@ function ProjectSettingsDialog() {
     if (project.data) {
       ConfirmationAPI.openConfirmationDialog({
         text: `Do you really want to delete the project "${project.data.title}"? This action cannot be undone and  will remove project and all of it's content including documents!`,
+        type: "DELETE",
         onAccept: () => {
           deleteProject(
             { projId: project.data.id },

--- a/frontend/src/components/ProjectSettings/tabs/ProjectDangerZone.tsx
+++ b/frontend/src/components/ProjectSettings/tabs/ProjectDangerZone.tsx
@@ -1,0 +1,75 @@
+import DeleteIcon from "@mui/icons-material/Delete";
+import { LoadingButton } from "@mui/lab";
+import { Box, Stack, TextField, Typography } from "@mui/material";
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ProjectRead } from "../../../api/openapi/models/ProjectRead.ts";
+import ProjectHooks from "../../../api/ProjectHooks.ts";
+import ConfirmationAPI from "../../ConfirmationDialog/ConfirmationAPI.ts";
+
+interface ProjectDangerZoneProps {
+  project: ProjectRead;
+}
+
+function ProjectDangerZone({ project }: ProjectDangerZoneProps) {
+  const { mutate: deleteProject, isPending } = ProjectHooks.useDeleteProject();
+  const navigate = useNavigate();
+
+  const [name, setName] = useState("");
+  const handleClickRemoveProject = useCallback(() => {
+    if (project) {
+      ConfirmationAPI.openConfirmationDialog({
+        text: `Do you really want to delete the project "${project.title}"? This action cannot be undone and  will remove project and all of it's content including documents!`,
+        type: "DELETE",
+        onAccept: () => {
+          navigate(`/projects`);
+          deleteProject(
+            { projId: project.id },
+            {
+              onSuccess: () => navigate(`/projects`),
+            },
+          );
+        },
+      });
+    }
+  }, [project, deleteProject, navigate]);
+
+  return (
+    <Box margin={2}>
+      <Stack direction="column" spacing={2} sx={{ width: "100%", alignItems: "left" }}>
+        <Typography variant="h6" component="div" flexShrink={0}>
+          Delete this entire project including all documents, annotations for you and every other person working on this
+          project. This cannot be undone!
+        </Typography>
+        <Stack direction="row" spacing={2} sx={{ width: "100%", alignItems: "left" }}>
+          <TextField
+            value={name}
+            fullWidth
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setName(event.target.value);
+            }}
+            helperText="Enter the name of the project if you really want to delete the project"
+            error={name != project.title}
+            onPaste={(e) => {
+              e.preventDefault();
+            }}
+          />
+          <LoadingButton
+            variant="contained"
+            color="error"
+            startIcon={<DeleteIcon />}
+            type="submit"
+            onClick={handleClickRemoveProject}
+            disabled={name != project.title}
+            loading={isPending}
+            loadingPosition="start"
+          >
+            Delete Project
+          </LoadingButton>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}
+
+export default ProjectDangerZone;

--- a/frontend/src/components/SourceDocument/DeleteSdocsButton.tsx
+++ b/frontend/src/components/SourceDocument/DeleteSdocsButton.tsx
@@ -30,6 +30,7 @@ function DeleteSdocsButton({ sdocIds, navigateTo, ...props }: DeleteSdocsButtonP
       text: `Do you really want to delete document(s) ${sdocIds.join(
         ", ",
       )}? This action cannot be undone and  will remove all annotations as well as memos associated with this document!`,
+      type: "DELETE",
       onAccept: () => {
         deleteDocuments(
           {

--- a/frontend/src/components/SourceDocument/DeleteSdocsMenuItem.tsx
+++ b/frontend/src/components/SourceDocument/DeleteSdocsMenuItem.tsx
@@ -28,6 +28,7 @@ function DeleteSdocsMenuItem({ sdocId, navigateTo, onClick, ...props }: DeleteSd
     if (!sdocId) return;
     ConfirmationAPI.openConfirmationDialog({
       text: `Do you really want to delete document(s) ${sdocId}? This action cannot be undone and  will remove all annotations as well as memos associated with this document!`,
+      type: "DELETE",
       onAccept: () => {
         deleteDocuments(
           {

--- a/frontend/src/components/SourceDocument/DocumentInformation/Info/MetadataEditMenu.tsx
+++ b/frontend/src/components/SourceDocument/DocumentInformation/Info/MetadataEditMenu.tsx
@@ -95,6 +95,7 @@ function MetadataEditMenu({ projectMetadata }: MetadataEditMenuProps) {
   const handleDeleteMetadata = useCallback(() => {
     ConfirmationAPI.openConfirmationDialog({
       text: `Do you really want to delete the ProjectMetadata ${projectMetadata.id}? This will remove metadata from all corresponding documents. This action cannot be undone!`,
+      type: "DELETE",
       onAccept: () => {
         const mutation = deleteMutation.mutate;
         mutation({

--- a/frontend/src/components/Tag/TagEditDialog.tsx
+++ b/frontend/src/components/Tag/TagEditDialog.tsx
@@ -91,6 +91,7 @@ function TagEditDialog() {
     if (tag) {
       ConfirmationAPI.openConfirmationDialog({
         text: `Do you really want to delete the tag "${tag.name}"? This action cannot be undone!`,
+        type: "DELETE",
         onAccept: () => {
           deleteTagMutation(
             { tagId: tag.id },

--- a/frontend/src/layouts/SideBar/SideBar.tsx
+++ b/frontend/src/layouts/SideBar/SideBar.tsx
@@ -94,6 +94,8 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
     dispatch(CRUDDialogActions.openProjectSettings());
   }, [dispatch]);
 
+  const selectedColor = "rgba(0, 0, 0, 0.5)";
+
   return (
     <Drawer
       variant="permanent"
@@ -154,14 +156,14 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
         {isInProject && (
           <List sx={{ py: 0 }}>
             <ListItem disablePadding sx={{ display: "block" }}>
-              <Tooltip title="Search (⌘⇧S)" placement="right" arrow disableHoverListener={isExpanded}>
+              <Tooltip title="Search in Corpus (⌘⇧S)" placement="right" arrow disableHoverListener={isExpanded}>
                 <ListItemButton
                   onClick={handleSearchMenuClick}
                   sx={{
                     minHeight: 48,
                     justifyContent: isExpanded ? "initial" : "center",
                     px: 2.5,
-                    bgcolor: isActive("search") ? "rgba(0, 0, 0, 0.08)" : "transparent",
+                    bgcolor: isActive("search") ? selectedColor : "transparent",
                   }}
                 >
                   <ListItemIcon
@@ -205,33 +207,6 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
             </ListItem>
 
             <ListItem disablePadding sx={{ display: "block" }}>
-              <Tooltip title="Perspectives (⌘M)" placement="right" arrow disableHoverListener={isExpanded}>
-                <ListItemButton
-                  component={Link}
-                  to={`/project/${projectId}/perspectives`}
-                  sx={{
-                    minHeight: 48,
-                    justifyContent: isExpanded ? "initial" : "center",
-                    px: 2.5,
-                    bgcolor: isActive("/perspectives") ? "rgba(0, 0, 0, 0.08)" : "transparent",
-                  }}
-                >
-                  <ListItemIcon
-                    sx={{
-                      minWidth: 0,
-                      mr: isExpanded ? 3 : "auto",
-                      justifyContent: "center",
-                      color: "primary.contrastText",
-                    }}
-                  >
-                    {getIconComponent(Icon.PERSPECTIVES)}
-                  </ListItemIcon>
-                  {isExpanded && <ListItemText>Perspectives</ListItemText>}
-                </ListItemButton>
-              </Tooltip>
-            </ListItem>
-
-            <ListItem disablePadding sx={{ display: "block" }}>
               <Tooltip title="Annotation (⌘⇧A)" placement="right" arrow disableHoverListener={isExpanded}>
                 <ListItemButton
                   component={Link}
@@ -240,7 +215,7 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
                     minHeight: 48,
                     justifyContent: isExpanded ? "initial" : "center",
                     px: 2.5,
-                    bgcolor: isActive("/annotation") ? "rgba(0, 0, 0, 0.08)" : "transparent",
+                    bgcolor: isActive("/annotation") ? selectedColor : "transparent",
                   }}
                 >
                   <ListItemIcon
@@ -263,6 +238,33 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
             </ListItem>
 
             <ListItem disablePadding sx={{ display: "block" }}>
+              <Tooltip title="Perspectives (⌘M)" placement="right" arrow disableHoverListener={isExpanded}>
+                <ListItemButton
+                  component={Link}
+                  to={`/project/${projectId}/perspectives`}
+                  sx={{
+                    minHeight: 48,
+                    justifyContent: isExpanded ? "initial" : "center",
+                    px: 2.5,
+                    bgcolor: isActive("/perspectives") ? selectedColor : "transparent",
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 0,
+                      mr: isExpanded ? 3 : "auto",
+                      justifyContent: "center",
+                      color: "primary.contrastText",
+                    }}
+                  >
+                    {getIconComponent(Icon.PERSPECTIVES)}
+                  </ListItemIcon>
+                  {isExpanded && <ListItemText>Perspectives</ListItemText>}
+                </ListItemButton>
+              </Tooltip>
+            </ListItem>
+
+            <ListItem disablePadding sx={{ display: "block" }}>
               <Tooltip title="Analysis (⌘⇧Y)" placement="right" arrow disableHoverListener={isExpanded}>
                 <ListItemButton
                   component={Link}
@@ -271,7 +273,7 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
                     minHeight: 48,
                     justifyContent: isExpanded ? "initial" : "center",
                     px: 2.5,
-                    bgcolor: isActive("/analysis") ? "rgba(0, 0, 0, 0.08)" : "transparent",
+                    bgcolor: isActive("/analysis") ? selectedColor : "transparent",
                   }}
                 >
                   <ListItemIcon
@@ -302,7 +304,7 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
                     minHeight: 48,
                     justifyContent: isExpanded ? "initial" : "center",
                     px: 2.5,
-                    bgcolor: isActive("/classifier") ? "rgba(0, 0, 0, 0.08)" : "transparent",
+                    bgcolor: isActive("/classifier") ? selectedColor : "transparent",
                   }}
                 >
                   <ListItemIcon
@@ -333,7 +335,7 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
                     minHeight: 48,
                     justifyContent: isExpanded ? "initial" : "center",
                     px: 2.5,
-                    bgcolor: isActive("/whiteboard") ? "rgba(0, 0, 0, 0.08)" : "transparent",
+                    bgcolor: isActive("/whiteboard") ? selectedColor : "transparent",
                   }}
                 >
                   <ListItemIcon
@@ -364,7 +366,7 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
                     minHeight: 48,
                     justifyContent: isExpanded ? "initial" : "center",
                     px: 2.5,
-                    bgcolor: isActive("/logbook") ? "rgba(0, 0, 0, 0.08)" : "transparent",
+                    bgcolor: isActive("/logbook") ? selectedColor : "transparent",
                   }}
                 >
                   <ListItemIcon
@@ -394,7 +396,7 @@ function SideBar({ isExpanded, onToggle, loginStatus, user, handleLogout, isInPr
                     minHeight: 48,
                     justifyContent: isExpanded ? "initial" : "center",
                     px: 2.5,
-                    bgcolor: isActive("/tools") ? "rgba(0, 0, 0, 0.08)" : "transparent",
+                    bgcolor: isActive("/tools") ? selectedColor : "transparent",
                   }}
                 >
                   <ListItemIcon

--- a/frontend/src/views/analysis/Analysis.tsx
+++ b/frontend/src/views/analysis/Analysis.tsx
@@ -2,6 +2,8 @@ import { Box } from "@mui/material";
 import ContentContainerLayout from "../../layouts/ContentLayouts/ContentContainerLayout.tsx";
 import AnalysisCard from "./AnalysisCard.tsx";
 
+const cardColor = "rgb(150, 200, 255)";
+
 function Analysis() {
   return (
     <ContentContainerLayout>
@@ -10,63 +12,63 @@ function Analysis() {
           to={"code-frequency"}
           title={"Code Frequency Analysis"}
           description={"Analyse the frequencies and occurrences of all codes in this project."}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"timeline"}
           title={"Timeline Analysis"}
           description={"Analyse the occurrence of concepts over time."}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"span-annotations"}
           title={"Span Annotation Table"}
           description={"View, search, edit span annotations in a table."}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"sentence-annotations"}
           title={"Sentence Annotation Table"}
           description={"View, search, edit sentence annotations in a table."}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"bbox-annotations"}
-          title={"BBox Annotation Table"}
+          title={"Bounding-Box Annotation Table"}
           description={"View, search, edit bbox annotations in a table."}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"word-frequency"}
           title={"Word Frequency Analysis"}
           description={"Analyse the frequencies and occurrences of all words in this project."}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"concepts-over-time-analysis"}
           title={"Concepts Over Time Analysis"}
           description={"Analyse the occurrence of concepts over time."}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"annotation-scaling"}
           title={"Annotation Scaling"}
           description={"Semi-automatically scale annotations"}
-          color={"#77dd77"}
+          color={cardColor}
         />
 
         <AnalysisCard
           to={"tag-recommendations"}
           title={"Tag Recommendations"}
           description={"Semi-automatically scale tags"}
-          color={"#77dd77"}
+          color={cardColor}
         />
       </Box>
     </ContentContainerLayout>

--- a/frontend/src/views/analysis/AnalysisCard.tsx
+++ b/frontend/src/views/analysis/AnalysisCard.tsx
@@ -13,7 +13,7 @@ function AnalysisCard({ to, title, description, color }: AnalysisCardProps) {
     <Card sx={{ width: 360, flexShrink: 0 }}>
       <CardActionArea component={Link} to={to}>
         <CardContent sx={{ padding: "0px !important" }}>
-          <Typography variant="body2" color="textPrimary" bgcolor={color || "lightgrey"} p={2} height={200}>
+          <Typography variant="subtitle2" color="textSecondary" bgcolor={color || "lightgrey"} p={2} height={200}>
             {description}
           </Typography>
         </CardContent>

--- a/frontend/src/views/analysis/BBoxAnnotationAnalysis/Toolbars/BulkDeleteBBoxAnnotationsButton.tsx
+++ b/frontend/src/views/analysis/BBoxAnnotationAnalysis/Toolbars/BulkDeleteBBoxAnnotationsButton.tsx
@@ -19,6 +19,7 @@ function BulkDeleteBBoxAnnotationsButton({ selectedData }: BulkDeleteBBoxAnnotat
       text: `Do you really want to delete ${selectedData.length} bbox annotation${
         selectedData.length > 1 ? "s" : ""
       }? This action cannot be undone!`,
+      type: "DELETE",
       onAccept: () => {
         deleteBulkMutation.mutate(
           { requestBody: selectedData.map((row) => row.id) },

--- a/frontend/src/views/analysis/SentAnnotationAnalysis/Toolbars/BulkDeleteSentAnnotationsButton.tsx
+++ b/frontend/src/views/analysis/SentAnnotationAnalysis/Toolbars/BulkDeleteSentAnnotationsButton.tsx
@@ -19,6 +19,7 @@ function BulkDeleteSentAnnotationsButton({ selectedData }: BulkDeleteSentAnnotat
       text: `Do you really want to delete ${selectedData.length} sentence annotation${
         selectedData.length > 1 ? "s" : ""
       }? This action cannot be undone!`,
+      type: "DELETE",
       onAccept: () => {
         deleteBulkMutation.mutate(
           { requestBody: selectedData.map((row) => row.id) },

--- a/frontend/src/views/analysis/SpanAnnotationAnalysis/Toolbars/BulkDeleteSpanAnnotationsButton.tsx
+++ b/frontend/src/views/analysis/SpanAnnotationAnalysis/Toolbars/BulkDeleteSpanAnnotationsButton.tsx
@@ -19,6 +19,7 @@ function BulkDeleteSpanAnnotationsButton({ selectedData }: BulkDeleteSpanAnnotat
       text: `Do you really want to delete ${selectedData.length} span annotation${
         selectedData.length > 1 ? "s" : ""
       }? This action cannot be undone!`,
+      type: "DELETE",
       onAccept: () => {
         deleteBulkMutation.mutate(
           { requestBody: selectedData.map((row) => row.id) },

--- a/frontend/src/views/annotation/AnnotationExplorer/SpanAnnotationDeleteMenuItem.tsx
+++ b/frontend/src/views/annotation/AnnotationExplorer/SpanAnnotationDeleteMenuItem.tsx
@@ -21,6 +21,7 @@ function SpanAnnotationDeleteMenuItem({
 
     ConfirmationAPI.openConfirmationDialog({
       text: `Do you really want to remove the SpanAnnotation ${annotationId}? You can reassign it later!`,
+      type: "DELETE",
       onAccept: () => {
         deleteMutation.mutate({ spanAnnotationToDelete: annotationId });
       },

--- a/frontend/src/views/annotation/TextAnnotator/TextAnnotator.tsx
+++ b/frontend/src/views/annotation/TextAnnotator/TextAnnotator.tsx
@@ -205,6 +205,7 @@ function TextAnnotator({ sdocData }: TextAnnotatorProps) {
   const handleCodeSelectorDeleteAnnotation = (annotation: Annotation) => {
     ConfirmationAPI.openConfirmationDialog({
       text: `Do you really want to remove the SpanAnnotation ${annotation.id}? You can reassign it later!`,
+      type: "DELETE",
       onAccept: () => {
         deleteMutation.mutate({ spanAnnotationToDelete: annotation as SpanAnnotationRead });
       },


### PR DESCRIPTION
Fixes #673  #668 #665 #663

1. code description is now optional (allowing faster code creation)
2. delete dialogs now explicitly  use 'delete' as action, with red icon button
3. move 'delete project' to a new 'danger zone' requiring typing the project name
4. active tab in sidebar is now highlighted stronger
5. analysis cards are colored blue-ish