### PR TITLE
use child codes as parent in classifier

### DIFF
--- a/backend/src/modules/classifier/classifier_crud.py
+++ b/backend/src/modules/classifier/classifier_crud.py
@@ -1,9 +1,10 @@
-from sqlalchemy import func
+from sqlalchemy import func, literal
 from sqlalchemy.orm import Session
 
 from core.annotation.annotation_document_orm import AnnotationDocumentORM
 from core.annotation.sentence_annotation_orm import SentenceAnnotationORM
 from core.annotation.span_annotation_orm import SpanAnnotationORM
+from core.code.code_crud import crud_code
 from core.code.code_orm import CodeORM
 from core.doc.source_document_orm import SourceDocumentORM
 from core.tag.tag_orm import TagORM
@@ -46,6 +47,7 @@ class CRUDClassifier(CRUDBase[ClassifierORM, ClassifierCreate, ClassifierUpdate]
         sdoc_ids: list[int],
         user_ids: list[int],
         class_ids: list[int],
+        merge_children_into_parent: bool = False,
     ) -> list[ClassifierDataset]:
         match model:
             case ClassifierModel.DOCUMENT:
@@ -80,23 +82,52 @@ class CRUDClassifier(CRUDBase[ClassifierORM, ClassifierCreate, ClassifierUpdate]
                     .all()
                 )
             case ClassifierModel.SPAN:
-                results = (
-                    db.query(
-                        CodeORM.id.label("class_id"),
-                        func.array_agg(SpanAnnotationORM.id).label("data_ids"),
-                        func.count(SpanAnnotationORM.id).label("num_examples"),
+                if merge_children_into_parent:
+                    codes = [
+                        [
+                            code.id
+                            for code in crud_code.read_with_children(db, code_id=id)
+                        ]
+                        for id in class_ids
+                    ]
+                else:
+                    codes = [class_ids]
+                results = []
+                for parent, child_codes in zip(class_ids, codes):
+                    result = (
+                        db.query(
+                            CodeORM.project_id,
+                            literal(parent).label("class_id")
+                            if merge_children_into_parent
+                            else CodeORM.id.label("class_id"),
+                            func.array_agg(SpanAnnotationORM.id).label("data_ids"),
+                            func.count(
+                                func.distinct(
+                                    func.row_(
+                                        SpanAnnotationORM.annotation_document_id,
+                                        SpanAnnotationORM.begin,
+                                        SpanAnnotationORM.end,
+                                    )
+                                )
+                            ).label("num_examples")
+                            if merge_children_into_parent
+                            else func.count(SpanAnnotationORM.id).label("num_examples"),
+                        )
+                        .join(SpanAnnotationORM.code)
+                        .join(SpanAnnotationORM.annotation_document)
+                        .filter(
+                            AnnotationDocumentORM.user_id.in_(user_ids),
+                            AnnotationDocumentORM.source_document_id.in_(sdoc_ids),
+                            CodeORM.id.in_(child_codes),
+                        )
+                        .group_by(
+                            CodeORM.project_id
+                            if merge_children_into_parent
+                            else CodeORM.id
+                        )
+                        .all()
                     )
-                    .join(SpanAnnotationORM.code)
-                    .join(SpanAnnotationORM.annotation_document)
-                    .filter(
-                        AnnotationDocumentORM.user_id.in_(user_ids),
-                        AnnotationDocumentORM.source_document_id.in_(sdoc_ids),
-                        CodeORM.id.in_(class_ids),
-                    )
-                    .group_by(CodeORM.id)
-                    .all()
-                )
-
+                    results.extend(result)
         return [
             ClassifierDataset(
                 class_id=row.class_id,
@@ -113,6 +144,7 @@ class CRUDClassifier(CRUDBase[ClassifierORM, ClassifierCreate, ClassifierUpdate]
         tag_ids: list[int],
         user_ids: list[int],
         class_ids: list[int],
+        merge_children_into_parent: bool = False,
     ) -> list[ClassifierDataset]:
         results = (
             db.query(SourceDocumentORM.id)
@@ -127,6 +159,7 @@ class CRUDClassifier(CRUDBase[ClassifierORM, ClassifierCreate, ClassifierUpdate]
             sdoc_ids=sdoc_ids,
             user_ids=user_ids,
             class_ids=class_ids,
+            merge_children_into_parent=merge_children_into_parent,
         )
 
     def add_evaluation(

--- a/backend/src/modules/classifier/classifier_dto.py
+++ b/backend/src/modules/classifier/classifier_dto.py
@@ -115,6 +115,9 @@ class ClassifierTrainingParams(BaseModel):
     # training data
     user_ids: list[int] = Field(description="List of user IDs to train on")
     tag_ids: list[int] = Field(description="List of Tag IDs to train on")
+    merge_children_into_parent: bool = Field(
+        description="Merge child codes in parent code?"
+    )
     # training settings
     epochs: int = Field(description="Number of epochs to train for")
     batch_size: int = Field(description="Batch size to use for training")

--- a/backend/src/modules/classifier/classifier_endpoint.py
+++ b/backend/src/modules/classifier/classifier_endpoint.py
@@ -85,13 +85,19 @@ def compute_dataset_statistics(
     user_ids: list[int],
     class_ids: list[int],
     model: ClassifierModel,
+    merge_children_into_parent: bool = False,
     db: Session = Depends(get_db_session),
     authz_user: AuthzUser = Depends(),
 ) -> list[ClassifierData]:
     authz_user.assert_in_project(proj_id)
 
     dataset = crud_classifier.read_dataset(
-        db=db, model=model, sdoc_ids=sdoc_ids, user_ids=user_ids, class_ids=class_ids
+        db=db,
+        model=model,
+        sdoc_ids=sdoc_ids,
+        user_ids=user_ids,
+        class_ids=class_ids,
+        merge_children_into_parent=merge_children_into_parent,
     )
     return [ClassifierData.model_validate(d) for d in dataset]
 
@@ -110,10 +116,16 @@ def compute_dataset_statistics2(
     model: ClassifierModel,
     db: Session = Depends(get_db_session),
     authz_user: AuthzUser = Depends(),
+    merge_children_into_parent: bool = False,
 ) -> list[ClassifierData]:
     authz_user.assert_in_project(proj_id)
 
     dataset = crud_classifier.read_dataset2(
-        db=db, model=model, tag_ids=tag_ids, user_ids=user_ids, class_ids=class_ids
+        db=db,
+        model=model,
+        tag_ids=tag_ids,
+        user_ids=user_ids,
+        class_ids=class_ids,
+        merge_children_into_parent=merge_children_into_parent,
     )
     return [ClassifierData.model_validate(d) for d in dataset]

--- a/backend/src/modules/classifier/models/span_class_model_service.py
+++ b/backend/src/modules/classifier/models/span_class_model_service.py
@@ -372,6 +372,8 @@ class SpanClassificationModelService(TextClassificationModelService):
         if not check_hf_model_exists(parameters.base_name):
             raise BaseModelDoesNotExistError(parameters.base_name)
 
+        merge_children_into_parent = parameters.merge_children_into_parent
+
         tokenizer = AutoTokenizer.from_pretrained(parameters.base_name)
         if parameters.chunk_size:
             tokenizer.model_max_length = parameters.chunk_size
@@ -393,12 +395,36 @@ class SpanClassificationModelService(TextClassificationModelService):
         job.update(current_step=1)
         # Get codes and create mapping
         codes = crud_code.read_by_ids(db=db, ids=parameters.class_ids)
-        classid2labelid: dict[int, int] = {
-            code.id: i + 1 for i, code in enumerate(codes)
-        }
+
+        if merge_children_into_parent:
+            child_codes = [
+                crud_code.read_with_children(db, code_id=id)
+                for id in parameters.class_ids
+            ]
+            classid2labelid: dict[int, int] = {
+                c.id: i + 1
+                for code, (i, parent) in zip(
+                    child_codes, enumerate(parameters.class_ids)
+                )
+                for c in code
+            }
+            class_ids = list(set(c.id for children in child_codes for c in children))
+            code2parent = {
+                code.id: parent
+                for children, parent in zip(child_codes, parameters.class_ids)
+                for code in children
+            }
+        else:
+            classid2labelid: dict[int, int] = {
+                code.id: i + 1 for i, code in enumerate(codes)
+            }
+            class_ids = parameters.class_ids
+            code2parent = {code: code for code in class_ids}
+
         classid2labelid[0] = 0
         id2label = {i + 1: code.name for i, code in enumerate(codes)}
         id2label[0] = "O"
+        code2parent[0] = 0
 
         # Build dataset
         user_id2sdoc_id2annotations, dataset = self._retrieve_and_build_dataset(
@@ -406,7 +432,7 @@ class SpanClassificationModelService(TextClassificationModelService):
             project_id=payload.project_id,
             tag_ids=parameters.tag_ids,
             user_ids=parameters.user_ids,
-            class_ids=parameters.class_ids,
+            class_ids=class_ids,
             classid2labelid=classid2labelid,
             tokenizer=tokenizer,
             use_chunking=True,
@@ -472,14 +498,14 @@ class SpanClassificationModelService(TextClassificationModelService):
             split_dataset["train"]["sdoc_id"], split_dataset["train"]["user_id"]
         ):
             for annotation in user_id2sdoc_id2annotations[user_id][sdoc_id]:
-                train_dataset_stats[annotation.code_id] += 1
+                train_dataset_stats[code2parent[annotation.code_id]] += 1
 
         eval_dataset_stats: dict[int, int] = {code.id: 0 for code in codes}
         for sdoc_id, user_id in zip(
             split_dataset["test"]["sdoc_id"], split_dataset["test"]["user_id"]
         ):
             for annotation in user_id2sdoc_id2annotations[user_id][sdoc_id]:
-                eval_dataset_stats[annotation.code_id] += 1
+                eval_dataset_stats[code2parent[annotation.code_id]] += 1
 
         # Calculate class weights
         # Count the occurrences of each label in the training set
@@ -491,7 +517,7 @@ class SpanClassificationModelService(TextClassificationModelService):
 
         # Calculate the weight for each label: A simple inverse frequency weighting
         total_tokens = sum(label_counts.values())
-        num_labels = len(classid2labelid)
+        num_labels = len(id2label)
         class_weights = [0.0] * num_labels
         for label, count in label_counts.items():
             if count > 0:
@@ -547,7 +573,7 @@ class SpanClassificationModelService(TextClassificationModelService):
             # Initialize the Lightning Model
             lightning_model = SpanClassificationLightningModel(
                 base_name=parameters.base_name,
-                num_labels=len(classid2labelid),
+                num_labels=len(id2label),
                 dropout=parameters.dropout,
                 learning_rate=parameters.learning_rate,
                 weight_decay=parameters.weight_decay,
@@ -592,7 +618,7 @@ class SpanClassificationModelService(TextClassificationModelService):
                 type=payload.model_type,
                 path=checkpoint_callback.best_model_path or "ERROR!",
                 project_id=payload.project_id,
-                labelid2classid={v: k for k, v in classid2labelid.items()},
+                labelid2classid={v: code2parent[k] for k, v in classid2labelid.items()},
                 train_data_stats=[
                     ClassifierData(class_id=code_id, num_examples=count)
                     for code_id, count in train_dataset_stats.items()

--- a/frontend/src/api/services/ClassifierService.ts
+++ b/frontend/src/api/services/ClassifierService.ts
@@ -82,10 +82,12 @@ export class ClassifierService {
     projId,
     model,
     requestBody,
+    mergeChildrenIntoParent = false,
   }: {
     projId: number;
     model: ClassifierModel;
     requestBody: Body_classifier_compute_dataset_statistics;
+    mergeChildrenIntoParent?: boolean;
   }): CancelablePromise<Array<ClassifierData>> {
     return __request(OpenAPI, {
       method: "POST",
@@ -95,6 +97,7 @@ export class ClassifierService {
       },
       query: {
         model: model,
+        merge_children_into_parent: mergeChildrenIntoParent,
       },
       body: requestBody,
       mediaType: "application/json",
@@ -112,10 +115,12 @@ export class ClassifierService {
     projId,
     model,
     requestBody,
+    mergeChildrenIntoParent = false,
   }: {
     projId: number;
     model: ClassifierModel;
     requestBody: Body_classifier_compute_dataset_statistics2;
+    mergeChildrenIntoParent?: boolean;
   }): CancelablePromise<Array<ClassifierData>> {
     return __request(OpenAPI, {
       method: "POST",
@@ -125,6 +130,7 @@ export class ClassifierService {
       },
       query: {
         model: model,
+        merge_children_into_parent: mergeChildrenIntoParent,
       },
       body: requestBody,
       mediaType: "application/json",

--- a/frontend/src/features/classifier/store/classifierSlice.ts
+++ b/frontend/src/features/classifier/store/classifierSlice.ts
@@ -13,6 +13,7 @@ interface ClassifierState {
   classifierSdocIds: number[];
   classifierUserIds: number[];
   classifierTagIds: number[];
+  classifierMergeChildren: boolean;
   classifierJobId?: string;
 }
 
@@ -27,6 +28,7 @@ const initialState: ClassifierState = {
   classifierSdocIds: [],
   classifierUserIds: [],
   classifierTagIds: [],
+  classifierMergeChildren: false,
   classifierJobId: undefined,
 };
 
@@ -55,8 +57,15 @@ const classifierSlice = createSlice({
       state.classifierClassIds = action.payload.classifierClassIds || [];
       state.classifierSdocIds = action.payload.classifierSdocIds || [];
     },
-    onClassifierDialogSelectClasses: (state, action: PayloadAction<number[]>) => {
-      state.classifierClassIds = action.payload;
+    onClassifierDialogSelectClasses: (
+      state,
+      action: PayloadAction<{
+        classIds: number[];
+        mergeChildren: boolean;
+      }>,
+    ) => {
+      state.classifierClassIds = action.payload.classIds;
+      state.classifierMergeChildren = action.payload.mergeChildren;
       state.classifierStep += 1;
     },
     onClassifierDialogSelectSdocs: (state, action: PayloadAction<number[]>) => {

--- a/frontend/src/features/classifier/views/dialog/_components/ClassSelectionStep.tsx
+++ b/frontend/src/features/classifier/views/dialog/_components/ClassSelectionStep.tsx
@@ -1,7 +1,18 @@
 import { CodeTable } from "@core/code";
 import { TagTable } from "@core/tag";
 import { ClassifierModel } from "@models/ClassifierModel";
-import { Alert, Box, Button, Card, CardHeader, DialogActions, Divider, Stack } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardHeader,
+  DialogActions,
+  Divider,
+  FormControlLabel,
+  Stack,
+  Switch,
+} from "@mui/material";
 import { useAppDispatch, useAppSelector } from "@store/storeHooks";
 import { MRT_RowSelectionState } from "material-react-table";
 import { useCallback, useState } from "react";
@@ -15,13 +26,14 @@ export function ClassSelectionStep() {
   // selection state
   const [rowSelectionModel, setRowSelectionModel] = useState<MRT_RowSelectionState>({});
   const selectedClassIds = Object.keys(rowSelectionModel).map((key) => parseInt(key));
+  const [mergeChildren, setMergeChildren] = useState<boolean>(false);
 
   // actions
   const dispatch = useAppDispatch();
   const handleNext = useCallback(() => {
     if (selectedClassIds.length === 0) return;
-    dispatch(ClassifierActions.onClassifierDialogSelectClasses(selectedClassIds));
-  }, [dispatch, selectedClassIds]);
+    dispatch(ClassifierActions.onClassifierDialogSelectClasses({ classIds: selectedClassIds, mergeChildren }));
+  }, [dispatch, selectedClassIds, mergeChildren]);
 
   const handleClose = useCallback(() => {
     dispatch(ClassifierActions.closeClassifierDialog());
@@ -53,11 +65,18 @@ export function ClassSelectionStep() {
               onRowSelectionChange={setRowSelectionModel}
             />
           ) : (
-            <CodeTable
-              projectId={projectId}
-              rowSelectionModel={rowSelectionModel}
-              onRowSelectionChange={setRowSelectionModel}
-            />
+            <>
+              <CodeTable
+                projectId={projectId}
+                rowSelectionModel={rowSelectionModel}
+                onRowSelectionChange={setRowSelectionModel}
+              />
+              <FormControlLabel
+                sx={{ margin: 1 }}
+                control={<Switch onChange={(_, checked) => setMergeChildren(checked)} />}
+                label="Merge child codes into parent?"
+              />
+            </>
           )}
         </Card>
       </Stack>

--- a/frontend/src/features/classifier/views/dialog/_components/DataSelection.tsx
+++ b/frontend/src/features/classifier/views/dialog/_components/DataSelection.tsx
@@ -14,6 +14,7 @@ export function DataSelection() {
   const classIds = useAppSelector((state) => state.classifier.classifierClassIds);
   const userIds = useAppSelector((state) => state.classifier.classifierUserIds);
   const tagIds = useAppSelector((state) => state.classifier.classifierTagIds);
+  const mergeChildren = useAppSelector((state) => state.classifier.classifierMergeChildren);
 
   // global server state
   const datasetStats = ClassifierHooks.useComputeDatasetStatistics2();
@@ -25,6 +26,7 @@ export function DataSelection() {
     datasetStats.mutate({
       projId: projectId,
       model: model!,
+      mergeChildrenIntoParent: mergeChildren,
       requestBody: {
         tag_ids: tagIds,
         user_ids: userIds,

--- a/frontend/src/features/classifier/views/dialog/_components/TrainingSettingsStep.tsx
+++ b/frontend/src/features/classifier/views/dialog/_components/TrainingSettingsStep.tsx
@@ -71,6 +71,7 @@ export function TrainingSettingsStep() {
   const classIds = useAppSelector((state) => state.classifier.classifierClassIds);
   const userIds = useAppSelector((state) => state.classifier.classifierUserIds);
   const tagIds = useAppSelector((state) => state.classifier.classifierTagIds);
+  const mergeChildren = useAppSelector((state) => state.classifier.classifierMergeChildren);
   const dispatch = useAppDispatch();
 
   // form state
@@ -113,6 +114,7 @@ export function TrainingSettingsStep() {
       // training data
       tag_ids: tagIds,
       user_ids: userIds,
+      merge_children_into_parent: mergeChildren,
       // training settings
       batch_size: data.batchSize,
       epochs: data.epochs,

--- a/frontend/src/models/ClassifierTrainingParams.ts
+++ b/frontend/src/models/ClassifierTrainingParams.ts
@@ -29,6 +29,10 @@ export type ClassifierTrainingParams = {
    */
   tag_ids: Array<number>;
   /**
+   * Merge child codes in parent code?
+   */
+  merge_children_into_parent: boolean;
+  /**
    * Number of epochs to train for
    */
   epochs: number;

--- a/frontend/src/openapi.json
+++ b/frontend/src/openapi.json
@@ -704,6 +704,12 @@
             "in": "query",
             "required": true,
             "schema": { "$ref": "#/components/schemas/ClassifierModel" }
+          },
+          {
+            "name": "merge_children_into_parent",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean", "default": false, "title": "Merge Children Into Parent" }
           }
         ],
         "requestBody": {
@@ -747,6 +753,12 @@
             "in": "query",
             "required": true,
             "schema": { "$ref": "#/components/schemas/ClassifierModel" }
+          },
+          {
+            "name": "merge_children_into_parent",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean", "default": false, "title": "Merge Children Into Parent" }
           }
         ],
         "requestBody": {
@@ -8052,6 +8064,11 @@
             "title": "Tag Ids",
             "description": "List of Tag IDs to train on"
           },
+          "merge_children_into_parent": {
+            "type": "boolean",
+            "title": "Merge Children Into Parent",
+            "description": "Merge child codes in parent code?"
+          },
           "epochs": { "type": "integer", "title": "Epochs", "description": "Number of epochs to train for" },
           "batch_size": { "type": "integer", "title": "Batch Size", "description": "Batch size to use for training" },
           "early_stopping": {
@@ -8108,6 +8125,7 @@
           "class_ids",
           "user_ids",
           "tag_ids",
+          "merge_children_into_parent",
           "epochs",
           "batch_size",
           "early_stopping",


### PR DESCRIPTION
Adds the option (during first step of span classifier wizard) to merge child codes into parents.

This changes both the dataset statistics (shown before training) as well as the actual training data.

Given a code hierarchy like

- a
  - a1
    - a11 
  - a2
- b 
  - b1
  - b2

and selecting a & b as codes, this will treat a1,a2,a11 as a, and b1,b2 as b. Thus, more fine-grained codes can be used for their coarse-grained parent codes recursively.
As child codes spans might overlap, only distinct spans (after in-place conversion to parent code) are counted for the dataset statistic. This fits the IO/BIO tagging scheme of the classifier, that can only output a single code per token.

If 'merge child codes into parents' is not used, behavior is as before.