### PR TITLE
allow for multiple OIDC providers to be configured

### DIFF
--- a/backend/src/config_schema.py
+++ b/backend/src/config_schema.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+from itertools import repeat
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 
 from common.doc_type import DocType
 from common.meta_type import MetaType
@@ -127,7 +135,17 @@ class AuthConfig(BaseModel):
 
     jwt: JwtConfig
     session: SessionConfig
-    oidc: OidcConfig
+    oidc: list[OidcConfig]
+
+    @field_validator("oidc", mode="before")
+    @classmethod
+    def transform(cls, value: dict) -> list[OidcConfig]:
+        # transforms the environemnt variables for OIDC configuration
+        # from comma-separeted lists into list of objects
+        split = {k: v.split(",") for k, v in value.items()}
+        tmp = list(zip(repeat(split.keys()), *split.values()))
+        result = [OidcConfig(**{k: v for k, v in zip(x[0], x[1:])}) for x in tmp]
+        return result
 
 
 class PersonConfig(BaseModel):

--- a/backend/src/core/auth/auth_endpoint.py
+++ b/backend/src/core/auth/auth_endpoint.py
@@ -189,17 +189,25 @@ def auth_content(
 
 
 @router.get("/oidc/login")
-async def oidc_login(request: Request, redirect_uri: str) -> Response:
+async def oidc_login(request: Request, provider: str, redirect_uri: str) -> Response:
     if not oauth_service.is_enabled:
         raise HTTPException(
             status_code=404, detail="OIDC authentication is not enabled"
         )
-    return await oauth_service.authentik.authorize_redirect(request, redirect_uri)
+    client = oauth_service.clients.get(provider)
+    if client is None:
+        raise HTTPException(
+            status_code=400, detail=f"provider '{provider} does not exist"
+        )
+    return await client.authorize_redirect(request, redirect_uri)
 
 
 @router.get("/oidc/callback")
 async def oidc_callback(
-    request: Request, response: Response, db: Session = Depends(get_db_session)
+    request: Request,
+    provider: str,
+    response: Response,
+    db: Session = Depends(get_db_session),
 ):
     if not oauth_service.is_enabled:
         raise HTTPException(
@@ -207,7 +215,9 @@ async def oidc_callback(
         )
 
     try:
-        user = await oauth_service.authenticate_oidc(db=db, request=request)
+        user = await oauth_service.authenticate_oidc(
+            db=db, request=request, provider=provider
+        )
     except Exception as e:
         raise HTTPException(status_code=401, detail=str(e))
 

--- a/backend/src/core/auth/auth_endpoint.py
+++ b/backend/src/core/auth/auth_endpoint.py
@@ -190,16 +190,10 @@ def auth_content(
 
 @router.get("/oidc/login")
 async def oidc_login(request: Request, provider: str, redirect_uri: str) -> Response:
-    if not oauth_service.is_enabled:
-        raise HTTPException(
-            status_code=404, detail="OIDC authentication is not enabled"
-        )
-    client = oauth_service.clients.get(provider)
-    if client is None:
-        raise HTTPException(
-            status_code=400, detail=f"provider '{provider} does not exist"
-        )
-    return await client.authorize_redirect(request, redirect_uri)
+    try:
+        return await oauth_service.login(request, provider, redirect_uri)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.get("/oidc/callback")
@@ -209,11 +203,6 @@ async def oidc_callback(
     response: Response,
     db: Session = Depends(get_db_session),
 ):
-    if not oauth_service.is_enabled:
-        raise HTTPException(
-            status_code=404, detail="OIDC authentication is not enabled"
-        )
-
     try:
         user = await oauth_service.authenticate_oidc(
             db=db, request=request, provider=provider

--- a/backend/src/core/auth/oauth_service.py
+++ b/backend/src/core/auth/oauth_service.py
@@ -19,32 +19,40 @@ class OAuthService(metaclass=SingletonMeta):
     def __new__(cls, *args, **kwargs):
         cls.mail_repo = MailRepo()
 
-        cls.is_enabled = conf.auth.oidc.enabled
-        cls.oauth = OAuth()
-
-        # Create Authentik OAuth client
-        cls.oauth.register(
-            name="authentik",
-            client_id=conf.auth.oidc.client_id,
-            client_secret=conf.auth.oidc.client_secret,
-            server_metadata_url=conf.auth.oidc.server_metadata_url,
-            client_kwargs={
-                "scope": "openid email profile",
-                "code_challenge_method": "S256",
-                "token_endpoint_auth_method": "client_secret_post",
-            },
-            id_token_encryption_alg="RSA-OAEP-256",
-            id_token_encryption_enc="A256CBC-HS512",
+        cls.is_enabled = len(conf.auth.oidc) > 0 and any(
+            x.enabled for x in conf.auth.oidc
         )
-        client = cls.oauth.create_client("authentik")
-        assert client is not None, "Failed to create Authentik OAuth client"
-        cls.authentik = client
+        cls.oauth = OAuth()
+        cls.clients = {}
+
+        for oidc in conf.auth.oidc:
+            if not oidc.enabled:
+                continue
+            # Create OAuth client
+            cls.oauth.register(
+                name=oidc.name,
+                client_id=oidc.client_id,
+                client_secret=oidc.client_secret,
+                server_metadata_url=oidc.server_metadata_url,
+                client_kwargs={
+                    "scope": "openid email profile",
+                    "code_challenge_method": "S256",
+                    "token_endpoint_auth_method": "client_secret_post",
+                },
+                id_token_encryption_alg="RSA-OAEP-256",
+                id_token_encryption_enc="A256CBC-HS512",
+            )
+            client = cls.oauth.create_client(oidc.name)
+            assert client is not None, "Failed to create Authentik OAuth client"
+            cls.clients[oidc.name] = client
 
         return super(OAuthService, cls).__new__(cls)
 
-    async def authenticate_oidc(self, db: Session, request: Request) -> UserORM:
+    async def authenticate_oidc(
+        self, db: Session, request: Request, provider: str
+    ) -> UserORM:
         try:
-            token = await self.authentik.authorize_access_token(request)
+            token = await self.clients[provider].authorize_access_token(request)
         except OAuthError as error:
             logger.error(f"OAuth error: {error}")
             raise error

--- a/backend/src/core/auth/oauth_service.py
+++ b/backend/src/core/auth/oauth_service.py
@@ -1,5 +1,6 @@
 import random
 import string
+from typing import Any
 
 from authlib.integrations.starlette_client import OAuth, OAuthError
 from fastapi import Request
@@ -17,19 +18,18 @@ from repos.mail_repo import MailRepo
 
 class OAuthService(metaclass=SingletonMeta):
     def __new__(cls, *args, **kwargs):
-        cls.mail_repo = MailRepo()
 
-        cls.is_enabled = len(conf.auth.oidc) > 0 and any(
+        cls.__is_enabled = len(conf.auth.oidc) > 0 and any(
             x.enabled for x in conf.auth.oidc
         )
-        cls.oauth = OAuth()
-        cls.clients = {}
+        cls.__oauth = OAuth()
+        cls.__clients: dict[str, Any] = {}
 
         for oidc in conf.auth.oidc:
             if not oidc.enabled:
                 continue
             # Create OAuth client
-            cls.oauth.register(
+            cls.__oauth.register(
                 name=oidc.name,
                 client_id=oidc.client_id,
                 client_secret=oidc.client_secret,
@@ -42,17 +42,22 @@ class OAuthService(metaclass=SingletonMeta):
                 id_token_encryption_alg="RSA-OAEP-256",
                 id_token_encryption_enc="A256CBC-HS512",
             )
-            client = cls.oauth.create_client(oidc.name)
+            client = cls.__oauth.create_client(oidc.name)
             assert client is not None, "Failed to create Authentik OAuth client"
-            cls.clients[oidc.name] = client
+            cls.__clients[oidc.name] = client
 
         return super(OAuthService, cls).__new__(cls)
+
+    async def login(self, request: Request, provider: str, redirect_uri: str):
+        client = self.__get_provider_client(provider)
+        return await client.authorize_redirect(request, redirect_uri)
 
     async def authenticate_oidc(
         self, db: Session, request: Request, provider: str
     ) -> UserORM:
         try:
-            token = await self.clients[provider].authorize_access_token(request)
+            client = self.__get_provider_client(provider)
+            token = await client.authorize_access_token(request)
         except OAuthError as error:
             logger.error(f"OAuth error: {error}")
             raise error
@@ -94,3 +99,11 @@ class OAuthService(metaclass=SingletonMeta):
         except Exception as e:
             logger.error(f"Error processing OIDC authentication: {e}")
             raise Exception("Authentication failed")
+
+    def __get_provider_client(self, provider: str):
+        if not self.__is_enabled:
+            raise Exception("OIDC authentication is not enabled")
+        client = self.__clients.get(provider)
+        if client is None:
+            raise Exception(f"OIDC provider '{provider} does not exist")
+        return client

--- a/backend/src/core/info/info_dto.py
+++ b/backend/src/core/info/info_dto.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field
 
 class InstanceInfo(BaseModel):
     is_oidc_enabled: bool = Field(description="Is OIDC enabled")
-    oidc_provider_name: str = Field(description="OIDC provider name")
+    oidc_provider_names: list[str] = Field(description="OIDC provider names")
     is_stable: bool = Field(description="Is stable")
     glitchtip_public_key: str | None = Field(description="Glitchtip public key")
     glitchtip_project_id: int | None = Field(description="Glitchtip project ID")

--- a/backend/src/core/info/info_endpoint.py
+++ b/backend/src/core/info/info_endpoint.py
@@ -25,8 +25,9 @@ def info():
             print(f"Error parsing Glitchtip DSN: {e}")
 
     return InstanceInfo(
-        is_oidc_enabled=conf.auth.oidc.enabled,
-        oidc_provider_name=conf.auth.oidc.name,
+        is_oidc_enabled=len(conf.auth.oidc) > 0
+        and any(x.enabled for x in conf.auth.oidc),
+        oidc_provider_names=[x.name for x in conf.auth.oidc if x.enabled],
         is_stable=conf.api.is_stable,
         glitchtip_public_key=glitchtip_public_key,
         glitchtip_project_id=glitchtip_project_id,

--- a/frontend/src/api/services/AuthenticationService.ts
+++ b/frontend/src/api/services/AuthenticationService.ts
@@ -106,11 +106,18 @@ export class AuthenticationService {
    * @returns any Successful Response
    * @throws ApiError
    */
-  public static oidcLogin({ redirectUri }: { redirectUri: string }): CancelablePromise<any> {
+  public static oidcLogin({
+    provider,
+    redirectUri,
+  }: {
+    provider: string;
+    redirectUri: string;
+  }): CancelablePromise<any> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/authentication/oidc/login",
       query: {
+        provider: provider,
         redirect_uri: redirectUri,
       },
       errors: {
@@ -123,10 +130,16 @@ export class AuthenticationService {
    * @returns any Successful Response
    * @throws ApiError
    */
-  public static oidcCallback(): CancelablePromise<any> {
+  public static oidcCallback({ provider }: { provider: string }): CancelablePromise<any> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/authentication/oidc/callback",
+      query: {
+        provider: provider,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
     });
   }
   /**

--- a/frontend/src/api/services/JobService.ts
+++ b/frontend/src/api/services/JobService.ts
@@ -103,43 +103,6 @@ export class JobService {
     });
   }
   /**
-   * Start DuplicateFinder job
-   * @returns DuplicateFinderJobRead Successful Response
-   * @throws ApiError
-   */
-  public static startDuplicateFinderJob({
-    requestBody,
-  }: {
-    requestBody: DuplicateFinderInput;
-  }): CancelablePromise<DuplicateFinderJobRead> {
-    return __request(OpenAPI, {
-      method: "POST",
-      url: "/job/duplicate_finder",
-      body: requestBody,
-      mediaType: "application/json",
-      errors: {
-        422: `Validation Error`,
-      },
-    });
-  }
-  /**
-   * Get DuplicateFinder job
-   * @returns DuplicateFinderJobRead Successful Response
-   * @throws ApiError
-   */
-  public static getDuplicateFinderJobById({ jobId }: { jobId: string }): CancelablePromise<DuplicateFinderJobRead> {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/job/duplicate_finder/{job_id}",
-      path: {
-        job_id: jobId,
-      },
-      errors: {
-        422: `Validation Error`,
-      },
-    });
-  }
-  /**
    * Start Ml job
    * @returns MlJobRead Successful Response
    * @throws ApiError
@@ -217,6 +180,43 @@ export class JobService {
       url: "/job/ml/project/{project_id}",
       path: {
         project_id: projectId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Start DuplicateFinder job
+   * @returns DuplicateFinderJobRead Successful Response
+   * @throws ApiError
+   */
+  public static startDuplicateFinderJob({
+    requestBody,
+  }: {
+    requestBody: DuplicateFinderInput;
+  }): CancelablePromise<DuplicateFinderJobRead> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/job/duplicate_finder",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Get DuplicateFinder job
+   * @returns DuplicateFinderJobRead Successful Response
+   * @throws ApiError
+   */
+  public static getDuplicateFinderJobById({ jobId }: { jobId: string }): CancelablePromise<DuplicateFinderJobRead> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/job/duplicate_finder/{job_id}",
+      path: {
+        job_id: jobId,
       },
       errors: {
         422: `Validation Error`,

--- a/frontend/src/api/services/JobService.ts
+++ b/frontend/src/api/services/JobService.ts
@@ -103,6 +103,43 @@ export class JobService {
     });
   }
   /**
+   * Start DuplicateFinder job
+   * @returns DuplicateFinderJobRead Successful Response
+   * @throws ApiError
+   */
+  public static startDuplicateFinderJob({
+    requestBody,
+  }: {
+    requestBody: DuplicateFinderInput;
+  }): CancelablePromise<DuplicateFinderJobRead> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/job/duplicate_finder",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Get DuplicateFinder job
+   * @returns DuplicateFinderJobRead Successful Response
+   * @throws ApiError
+   */
+  public static getDuplicateFinderJobById({ jobId }: { jobId: string }): CancelablePromise<DuplicateFinderJobRead> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/job/duplicate_finder/{job_id}",
+      path: {
+        job_id: jobId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
    * Start Ml job
    * @returns MlJobRead Successful Response
    * @throws ApiError
@@ -180,43 +217,6 @@ export class JobService {
       url: "/job/ml/project/{project_id}",
       path: {
         project_id: projectId,
-      },
-      errors: {
-        422: `Validation Error`,
-      },
-    });
-  }
-  /**
-   * Start DuplicateFinder job
-   * @returns DuplicateFinderJobRead Successful Response
-   * @throws ApiError
-   */
-  public static startDuplicateFinderJob({
-    requestBody,
-  }: {
-    requestBody: DuplicateFinderInput;
-  }): CancelablePromise<DuplicateFinderJobRead> {
-    return __request(OpenAPI, {
-      method: "POST",
-      url: "/job/duplicate_finder",
-      body: requestBody,
-      mediaType: "application/json",
-      errors: {
-        422: `Validation Error`,
-      },
-    });
-  }
-  /**
-   * Get DuplicateFinder job
-   * @returns DuplicateFinderJobRead Successful Response
-   * @throws ApiError
-   */
-  public static getDuplicateFinderJobById({ jobId }: { jobId: string }): CancelablePromise<DuplicateFinderJobRead> {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/job/duplicate_finder/{job_id}",
-      path: {
-        job_id: jobId,
       },
       errors: {
         422: `Validation Error`,

--- a/frontend/src/core/auth/HandleOIDCLogin.ts
+++ b/frontend/src/core/auth/HandleOIDCLogin.ts
@@ -1,6 +1,9 @@
 import { UserAuthorizationHeaderData } from "@models/UserAuthorizationHeaderData";
 
-export function handleOIDCLogin(updateAuthData: (authData: UserAuthorizationHeaderData) => void): void {
+export function handleOIDCLogin(
+  provider: string,
+  updateAuthData: (authData: UserAuthorizationHeaderData) => void,
+): void {
   const width = 600;
   const height = 600;
   const left = window.screenX + (window.outerWidth - width) / 2;
@@ -8,7 +11,7 @@ export function handleOIDCLogin(updateAuthData: (authData: UserAuthorizationHead
 
   // Open the OIDC login window
   const loginWindow = window.open(
-    `/api/authentication/oidc/login?redirect_uri=${encodeURIComponent(window.location.origin + "/api/authentication/oidc/callback")}`,
+    `/api/authentication/oidc/login?provider=${provider}&redirect_uri=${encodeURIComponent(window.location.origin + `/api/authentication/oidc/callback?provider=${provider}`)}`,
     "oidc_login",
     `width=${width},height=${height},left=${left},top=${top}`,
   );

--- a/frontend/src/features/auth/views/login/LoginView.tsx
+++ b/frontend/src/features/auth/views/login/LoginView.tsx
@@ -145,15 +145,19 @@ export function LoginView() {
                     </Typography>
                   </Divider>
                 </Box>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  fullWidth
-                  sx={{ mt: 2 }}
-                  onClick={() => handleOIDCLogin(updateAuthData)}
-                >
-                  Sign in with {instanceInfo.oidc_provider_name}
-                </Button>
+                {instanceInfo.oidc_provider_names.map((provider_name) => {
+                  return (
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      fullWidth
+                      sx={{ mt: 2 }}
+                      onClick={() => handleOIDCLogin(provider_name, updateAuthData)}
+                    >
+                      Sign in with {provider_name}
+                    </Button>
+                  );
+                })}
               </>
             )}
           </CardContent>

--- a/frontend/src/models/InstanceInfo.ts
+++ b/frontend/src/models/InstanceInfo.ts
@@ -8,9 +8,9 @@ export type InstanceInfo = {
    */
   is_oidc_enabled: boolean;
   /**
-   * OIDC provider name
+   * OIDC provider names
    */
-  oidc_provider_name: string;
+  oidc_provider_names: Array<string>;
   /**
    * Is stable
    */

--- a/frontend/src/openapi.json
+++ b/frontend/src/openapi.json
@@ -355,6 +355,7 @@
         "summary": "Oidc Login",
         "operationId": "oidc_login",
         "parameters": [
+          { "name": "provider", "in": "query", "required": true, "schema": { "type": "string", "title": "Provider" } },
           {
             "name": "redirect_uri",
             "in": "query",
@@ -376,8 +377,15 @@
         "tags": ["authentication"],
         "summary": "Oidc Callback",
         "operationId": "oidc_callback",
+        "parameters": [
+          { "name": "provider", "in": "query", "required": true, "schema": { "type": "string", "title": "Provider" } }
+        ],
         "responses": {
-          "200": { "description": "Successful Response", "content": { "application/json": { "schema": {} } } }
+          "200": { "description": "Successful Response", "content": { "application/json": { "schema": {} } } },
+          "422": {
+            "description": "Validation Error",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HTTPValidationError" } } }
+          }
         }
       }
     },
@@ -1968,6 +1976,49 @@
         }
       }
     },
+    "/job/duplicate_finder": {
+      "post": {
+        "tags": ["job"],
+        "summary": "Start DuplicateFinder job",
+        "operationId": "start_duplicate_finder_job",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DuplicateFinderInput" } } },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DuplicateFinderJobRead" } } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HTTPValidationError" } } }
+          }
+        },
+        "security": [{ "OAuth2PasswordBearer": [] }]
+      }
+    },
+    "/job/duplicate_finder/{job_id}": {
+      "get": {
+        "tags": ["job"],
+        "summary": "Get DuplicateFinder job",
+        "operationId": "get_duplicate_finder_job_by_id",
+        "security": [{ "OAuth2PasswordBearer": [] }],
+        "parameters": [
+          { "name": "job_id", "in": "path", "required": true, "schema": { "type": "string", "title": "Job Id" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DuplicateFinderJobRead" } } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HTTPValidationError" } } }
+          }
+        }
+      }
+    },
     "/job/ml": {
       "post": {
         "tags": ["job"],
@@ -2079,49 +2130,6 @@
                 }
               }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HTTPValidationError" } } }
-          }
-        }
-      }
-    },
-    "/job/duplicate_finder": {
-      "post": {
-        "tags": ["job"],
-        "summary": "Start DuplicateFinder job",
-        "operationId": "start_duplicate_finder_job",
-        "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DuplicateFinderInput" } } },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DuplicateFinderJobRead" } } }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/HTTPValidationError" } } }
-          }
-        },
-        "security": [{ "OAuth2PasswordBearer": [] }]
-      }
-    },
-    "/job/duplicate_finder/{job_id}": {
-      "get": {
-        "tags": ["job"],
-        "summary": "Get DuplicateFinder job",
-        "operationId": "get_duplicate_finder_job_by_id",
-        "security": [{ "OAuth2PasswordBearer": [] }],
-        "parameters": [
-          { "name": "job_id", "in": "path", "required": true, "schema": { "type": "string", "title": "Job Id" } }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DuplicateFinderJobRead" } } }
           },
           "422": {
             "description": "Validation Error",
@@ -9698,10 +9706,11 @@
       "InstanceInfo": {
         "properties": {
           "is_oidc_enabled": { "type": "boolean", "title": "Is Oidc Enabled", "description": "Is OIDC enabled" },
-          "oidc_provider_name": {
-            "type": "string",
-            "title": "Oidc Provider Name",
-            "description": "OIDC provider name"
+          "oidc_provider_names": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Oidc Provider Names",
+            "description": "OIDC provider names"
           },
           "is_stable": { "type": "boolean", "title": "Is Stable", "description": "Is stable" },
           "glitchtip_public_key": {
@@ -9718,7 +9727,7 @@
         "type": "object",
         "required": [
           "is_oidc_enabled",
-          "oidc_provider_name",
+          "oidc_provider_names",
           "is_stable",
           "glitchtip_public_key",
           "glitchtip_project_id"


### PR DESCRIPTION
multiple OIDC providers can now be configured via env variables by using separated lists for:

* `AUTH_OIDC_ENABLED`
* `AUTH_OIDC_PROVIDER_NAME`
* `AUTH_OIDC_CLIENT_ID`
* `AUTH_OIDC_CLIENT_SECRET`
* `AUTH_OIDC_SERVER_METADATA_URL`

e.g. `AUTH_OIDC_PROVIDER_NAME=dummy-authentik,HCDS` etc.
resulting in

<img width="551" height="541" alt="Screenshot 2026-07-15 at 14 48 22" src="https://github.com/user-attachments/assets/3f3d02e1-f9df-4dca-9673-467d8b41a70e" />

**beware of the security implications**
if two providers return the same email, both providers yield access to the same DATS account!
do not use this feature, if any of the configured providers is not under your control