### PR TITLE
added new feature: code shortcuts for quick annotations

### DIFF
--- a/frontend/src/features/annotation/_components/annotation-menu/AnnotationMenu.tsx
+++ b/frontend/src/features/annotation/_components/annotation-menu/AnnotationMenu.tsx
@@ -2,6 +2,7 @@ import { CodeHooks } from "@api/hooks/CodeHooks";
 import { getIconComponent, Icon } from "@components/icons";
 import { NamedObjWithParentWithLevel, useWithLevel } from "@components/tree-explorer";
 import { MemoButton } from "@core/memo";
+import { useAuth } from "@core/auth";
 import { AttachedObjectType } from "@models/AttachedObjectType";
 import { BBoxAnnotationRead } from "@models/BBoxAnnotationRead";
 import { CodeRead } from "@models/CodeRead";
@@ -18,11 +19,14 @@ import {
   PopoverPosition,
   TextField,
   Tooltip,
+  Typography,
   UseAutocompleteProps,
 } from "@mui/material";
 import { useOpenDialog } from "@store/global/dialogBusSlice";
-import { useEffect, useImperativeHandle, useMemo, useState } from "react";
+import { useAppSelector } from "@store/storeHooks";
+import { useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { Annotation, Annotations } from "../../_types/Annotation";
+import { CODE_SHORTCUT_KEYS, CodeShortcutKey, selectCodeShortcuts } from "../../store/codeShortcutSlice";
 import { useComputeCodesForSelection } from "./_hooks/useComputeCodesForSelection";
 
 const filter = createFilterOptions<ICodeFilterWithLevel>();
@@ -43,10 +47,15 @@ export interface AnnotationMenuHandle {
 
 interface ICodeFilterWithLevel extends NamedObjWithParentWithLevel<CodeRead> {
   title: string;
+  shortcutKey?: CodeShortcutKey;
 }
 
 export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplicate }: AnnotationMenuProps) => {
   const openCodeCreate = useOpenDialog("codeCreate");
+  const { user } = useAuth();
+  const projectId = useAppSelector((state) => state.project.projectId);
+  const bindings = useAppSelector((state) => selectCodeShortcuts(state, user?.id, projectId));
+  const submissionLockedRef = useRef(false);
 
   // local client state
   const [position, setPosition] = useState<PopoverPosition>({ top: 0, left: 0 });
@@ -60,16 +69,31 @@ export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplic
 
   // computed
   const codes = useComputeCodesForSelection();
+  const enabledCodes = CodeHooks.useGetEnabledCodes();
   const codeTree = useWithLevel(codes, codes[0]?.parent_id ?? null);
   const codeOptions: ICodeFilterWithLevel[] = useMemo(() => {
-    return codeTree.map((c) => ({
+    const scopedOptions = codeTree.map((c) => ({
       ...c,
       title: c.data.name,
     }));
-  }, [codeTree]);
+    const enabledCodesById = new Map((enabledCodes.data ?? []).map((code) => [code.id, code]));
+    const shortcutOptions = CODE_SHORTCUT_KEYS.flatMap((shortcutKey) => {
+      const codeId = bindings[shortcutKey];
+      const code = codeId === undefined ? undefined : enabledCodesById.get(codeId);
+      if (!code) {
+        return [];
+      }
+
+      return [{ data: code, title: code.name, level: 0, shortcutKey }];
+    });
+    const shortcutCodeIds = new Set(shortcutOptions.map((option) => option.data.id));
+
+    return [...shortcutOptions, ...scopedOptions.filter((option) => !shortcutCodeIds.has(option.data.id))];
+  }, [bindings, codeTree, enabledCodes.data]);
 
   // methods
   const openAnnotationMenu = (position: PopoverPosition, annotations?: Annotations) => {
+    submissionLockedRef.current = false;
     setEditingAnnotation(undefined);
     setDuplicatingAnnotation(undefined);
     setAnnotationsToEdit(annotations);
@@ -144,6 +168,11 @@ export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplic
 
   // submit the code selector (either we edited or created a new code)
   const submit = (code: CodeRead, isNewCode: boolean) => {
+    if (submissionLockedRef.current) {
+      return;
+    }
+    submissionLockedRef.current = true;
+
     // when the user selected an annotation to edit, we were editing
     if (editingAnnotation !== undefined) {
       onEdit(editingAnnotation, code.id);
@@ -154,6 +183,35 @@ export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplic
       onAdd(code.id, isNewCode);
     }
     closeAnnotationMenu();
+  };
+
+  const handleShortcutKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      !showCodeSelection ||
+      event.repeat ||
+      event.nativeEvent.isComposing ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.altKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    const shortcutKey = CODE_SHORTCUT_KEYS.find((candidate) => candidate === event.key);
+    if (!shortcutKey) {
+      return;
+    }
+
+    const codeId = bindings[shortcutKey];
+    const code = codeId === undefined ? undefined : enabledCodes.data?.find((candidate) => candidate.id === codeId);
+    if (!code) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    submit(code, false);
   };
 
   return (
@@ -170,6 +228,7 @@ export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplic
         vertical: "top",
         horizontal: "left",
       }}
+      onKeyDownCapture={handleShortcutKeyDown}
     >
       {!showCodeSelection && annotationsToEdit ? (
         <List dense>
@@ -191,7 +250,11 @@ export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplic
             value={autoCompleteValue}
             onChange={handleChange}
             filterOptions={(options, params) => {
-              const filtered = filter(options, params);
+              const shortcutOptions = options.filter((option) => option.shortcutKey !== undefined);
+              const filtered = filter(
+                options.filter((option) => option.shortcutKey === undefined),
+                params,
+              );
 
               const { inputValue } = params;
               // Suggest the creation of a new value
@@ -214,7 +277,7 @@ export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplic
                 });
               }
 
-              return filtered;
+              return [...shortcutOptions, ...filtered];
             }}
             options={codeOptions}
             getOptionLabel={(option) => {
@@ -228,8 +291,27 @@ export const AnnotationMenu = ({ ref, onClose, onAdd, onEdit, onDelete, onDuplic
               const indent = option.level * 10 + 10;
               return (
                 <li {...props} key={option.data.id} style={{ paddingLeft: indent }}>
-                  <Box style={{ width: 20, height: 20, backgroundColor: option.data.color, marginRight: 8 }}></Box>{" "}
-                  {option.title}
+                  <Box sx={{ display: "flex", alignItems: "center", width: "100%", minWidth: 0 }}>
+                    <Box sx={{ width: 20, height: 20, backgroundColor: option.data.color, mr: 1, flexShrink: 0 }} />
+                    <Typography noWrap>{option.title}</Typography>
+                    {option.shortcutKey !== undefined ? (
+                      <Box
+                        component="kbd"
+                        sx={{
+                          ml: "auto",
+                          px: 1,
+                          py: 0.25,
+                          border: 1,
+                          borderColor: "divider",
+                          borderRadius: 1,
+                          bgcolor: "action.hover",
+                          fontFamily: "monospace",
+                        }}
+                      >
+                        {option.shortcutKey}
+                      </Box>
+                    ) : null}
+                  </Box>
                 </li>
               );
             }}

--- a/frontend/src/features/annotation/_components/toolbar/AnnotationToolbar.tsx
+++ b/frontend/src/features/annotation/_components/toolbar/AnnotationToolbar.tsx
@@ -9,7 +9,9 @@ import ChromeReaderModeIcon from "@mui/icons-material/ChromeReaderMode";
 import DoNotDisturbIcon from "@mui/icons-material/DoNotDisturb";
 import FormatOverlineIcon from "@mui/icons-material/FormatOverline";
 import FormatStrikethroughIcon from "@mui/icons-material/FormatStrikethrough";
-import { ToggleButton, ToggleButtonGroup, Tooltip } from "@mui/material";
+import KeyboardIcon from "@mui/icons-material/Keyboard";
+import { IconButton, ToggleButton, ToggleButtonGroup, Tooltip } from "@mui/material";
+import { useOpenDialog } from "@store/global/dialogBusSlice";
 import { useAppDispatch, useAppSelector } from "@store/storeHooks";
 import { AnnotationRouteAPI } from "../../_hooks/annotationRouteAPI";
 import { AnnotationMode } from "../../_types/AnnotationMode";
@@ -24,6 +26,7 @@ interface AnnotationToolbarProps {
 }
 
 export function AnnotationToolbar({ sdoc }: AnnotationToolbarProps) {
+  const openCodeShortcutManager = useOpenDialog("codeShortcutManager");
   // global client state (URL search params)
   const { compareWithUserId } = AnnotationRouteAPI.useSearch();
   const isCompareMode = compareWithUserId !== undefined;
@@ -95,6 +98,11 @@ export function AnnotationToolbar({ sdoc }: AnnotationToolbarProps) {
             </ToggleButtonGroup>
           )}
           <LLMAssistanceButton sdocIds={[sdoc.id]} projectId={sdoc.project_id} />
+          <Tooltip title="Manage code shortcuts" placement="bottom">
+            <IconButton onClick={() => openCodeShortcutManager()}>
+              <KeyboardIcon />
+            </IconButton>
+          </Tooltip>
         </>
       ) : null}
     </DATSToolbar>

--- a/frontend/src/features/annotation/index.ts
+++ b/frontend/src/features/annotation/index.ts
@@ -1,4 +1,6 @@
 export { annoReducer } from "./store/annoSlice";
+export { codeShortcutReducer } from "./store/codeShortcutSlice";
 export * from "./views/fallback/AnnotationFallbackView";
 export * from "./views/main/AnnotationView";
 export * from "./views/main/annotationViewLoader";
+export * from "./views/shortcut-dialog";

--- a/frontend/src/features/annotation/store/codeShortcutSlice.ts
+++ b/frontend/src/features/annotation/store/codeShortcutSlice.ts
@@ -1,0 +1,112 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "@store/store";
+import { persistReducer } from "redux-persist";
+import createWebStorage from "redux-persist/es/storage/createWebStorage";
+
+const storage = createWebStorage("local");
+
+export type CodeShortcutKey = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+
+export const CODE_SHORTCUT_KEYS: CodeShortcutKey[] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+
+export type CodeShortcutBindings = Partial<Record<CodeShortcutKey, number>>;
+
+interface CodeShortcutState {
+  bindingsByUserAndProject: Record<string, Record<string, CodeShortcutBindings>>;
+}
+
+interface CodeShortcutScope {
+  userId: number;
+  projectId: number;
+}
+
+interface AssignCodeShortcutPayload extends CodeShortcutScope {
+  key: CodeShortcutKey;
+  codeId: number;
+}
+
+interface ClearCodeShortcutPayload extends CodeShortcutScope {
+  key: CodeShortcutKey;
+}
+
+interface ReconcileCodeShortcutsPayload extends CodeShortcutScope {
+  validCodeIds: number[];
+}
+
+const initialState: CodeShortcutState = {
+  bindingsByUserAndProject: {},
+};
+
+const codeShortcutSlice = createSlice({
+  name: "codeShortcuts",
+  initialState,
+  reducers: {
+    assign: (state, action: PayloadAction<AssignCodeShortcutPayload>) => {
+      const { userId, projectId, key, codeId } = action.payload;
+      const userBindings = (state.bindingsByUserAndProject[userId] ??= {});
+      const projectBindings = (userBindings[projectId] ??= {});
+
+      for (const shortcutKey of CODE_SHORTCUT_KEYS) {
+        if (projectBindings[shortcutKey] === codeId) {
+          delete projectBindings[shortcutKey];
+        }
+      }
+
+      projectBindings[key] = codeId;
+    },
+    clear: (state, action: PayloadAction<ClearCodeShortcutPayload>) => {
+      const { userId, projectId, key } = action.payload;
+      const projectBindings = state.bindingsByUserAndProject[userId]?.[projectId];
+      if (!projectBindings) {
+        return;
+      }
+
+      delete projectBindings[key];
+    },
+    clearAll: (state, action: PayloadAction<CodeShortcutScope>) => {
+      const { userId, projectId } = action.payload;
+      const userBindings = state.bindingsByUserAndProject[userId];
+      if (!userBindings) {
+        return;
+      }
+
+      delete userBindings[projectId];
+    },
+    reconcile: (state, action: PayloadAction<ReconcileCodeShortcutsPayload>) => {
+      const { userId, projectId, validCodeIds } = action.payload;
+      const projectBindings = state.bindingsByUserAndProject[userId]?.[projectId];
+      if (!projectBindings) {
+        return;
+      }
+
+      for (const shortcutKey of CODE_SHORTCUT_KEYS) {
+        const codeId = projectBindings[shortcutKey];
+        if (codeId !== undefined && !validCodeIds.includes(codeId)) {
+          delete projectBindings[shortcutKey];
+        }
+      }
+    },
+  },
+});
+
+const EMPTY_BINDINGS: CodeShortcutBindings = {};
+
+export const selectCodeShortcuts = (state: RootState, userId: number | undefined, projectId: number | undefined) => {
+  if (userId === undefined || projectId === undefined) {
+    return EMPTY_BINDINGS;
+  }
+
+  return state.codeShortcuts.bindingsByUserAndProject[userId]?.[projectId] ?? EMPTY_BINDINGS;
+};
+
+export const CodeShortcutActions = codeShortcutSlice.actions;
+
+export const codeShortcutReducer = {
+  [codeShortcutSlice.name]: persistReducer(
+    {
+      key: codeShortcutSlice.name,
+      storage,
+    },
+    codeShortcutSlice.reducer,
+  ),
+};

--- a/frontend/src/features/annotation/views/shortcut-dialog/CodeShortcutManagerDialog.tsx
+++ b/frontend/src/features/annotation/views/shortcut-dialog/CodeShortcutManagerDialog.tsx
@@ -1,0 +1,217 @@
+import { DATSDialogHeader } from "@components/DATSDialogHeader";
+import { ITree, TreeExplorer } from "@components/tree-explorer";
+import { useAuth } from "@core/auth";
+import { CodeRenderer, useComputeCodeTree } from "@core/code";
+import { useOpenConfirmationDialog } from "@core/notification";
+import { useDialogMaximize } from "@hooks/useDialogMaximize";
+import { CodeRead } from "@models/CodeRead";
+import BackspaceIcon from "@mui/icons-material/Backspace";
+import KeyboardIcon from "@mui/icons-material/Keyboard";
+import SquareIcon from "@mui/icons-material/Square";
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  IconButton,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { useDialog } from "@store/global/dialogBusSlice";
+import { useAppDispatch, useAppSelector } from "@store/storeHooks";
+import { useCallback, useMemo, useState } from "react";
+import {
+  CODE_SHORTCUT_KEYS,
+  CodeShortcutActions,
+  CodeShortcutKey,
+  selectCodeShortcuts,
+} from "../../store/codeShortcutSlice";
+
+interface CodeShortcutManagerDialogProps {
+  projectId: number;
+}
+
+export function CodeShortcutManagerDialog({ projectId }: CodeShortcutManagerDialogProps) {
+  const { isOpen, close } = useDialog("codeShortcutManager");
+  const { isMaximized, toggleMaximize } = useDialogMaximize();
+  const openConfirmationDialog = useOpenConfirmationDialog();
+  const dispatch = useAppDispatch();
+  const { user } = useAuth();
+  const { codeTree, allCodes } = useComputeCodeTree();
+  const bindings = useAppSelector((state) => selectCodeShortcuts(state, user?.id, projectId));
+
+  const [selectedCodeId, setSelectedCodeId] = useState<number>();
+  const [expandedCodeIds, setExpandedCodeIds] = useState<string[]>([]);
+  const [codeFilter, setCodeFilter] = useState("");
+
+  const codesById = useMemo(() => new Map((allCodes.data ?? []).map((code) => [code.id, code])), [allCodes.data]);
+  const selectedCode = selectedCodeId === undefined ? undefined : codesById.get(selectedCodeId);
+
+  const handleSelectedCodeChange = useCallback(
+    (_event: React.SyntheticEvent | null, nodeIds: string[] | string | null) => {
+      if (nodeIds === null) {
+        setSelectedCodeId(undefined);
+        return;
+      }
+
+      setSelectedCodeId(parseInt(Array.isArray(nodeIds) ? nodeIds[0] : nodeIds, 10));
+    },
+    [],
+  );
+
+  const handleAssign = useCallback(
+    (key: CodeShortcutKey) => {
+      if (!user || !selectedCode) {
+        return;
+      }
+
+      dispatch(
+        CodeShortcutActions.assign({
+          userId: user.id,
+          projectId,
+          key,
+          codeId: selectedCode.id,
+        }),
+      );
+    },
+    [dispatch, projectId, selectedCode, user],
+  );
+
+  const handleClear = useCallback(
+    (key: CodeShortcutKey) => {
+      if (!user) {
+        return;
+      }
+
+      dispatch(CodeShortcutActions.clear({ userId: user.id, projectId, key }));
+    },
+    [dispatch, projectId, user],
+  );
+
+  const handleClearAll = useCallback(() => {
+    if (!user) {
+      return;
+    }
+
+    openConfirmationDialog({
+      type: "DELETE",
+      text: "Do you really want to clear all code shortcuts for this project?",
+      onAccept: () => dispatch(CodeShortcutActions.clearAll({ userId: user.id, projectId })),
+    });
+  }, [dispatch, openConfirmationDialog, projectId, user]);
+
+  const renderNode = useCallback(
+    (node: ITree<CodeRead>) => (
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: "inherit",
+          flexGrow: 1,
+        }}
+      >
+        {node.data.name}
+      </Typography>
+    ),
+    [],
+  );
+
+  return (
+    <Dialog open={isOpen} onClose={close} maxWidth="lg" fullWidth fullScreen={isMaximized}>
+      <DATSDialogHeader
+        title="Code shortcuts"
+        onClose={close}
+        isMaximized={isMaximized}
+        onToggleMaximize={toggleMaximize}
+      />
+      <DialogContent sx={{ minHeight: 560 }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", md: "minmax(320px, 1fr) minmax(360px, 1fr)" },
+            gap: 3,
+            height: "100%",
+          }}
+        >
+          <Paper variant="outlined" sx={{ minHeight: 500, overflow: "hidden" }}>
+            {codeTree ? (
+              <TreeExplorer
+                dataTree={codeTree}
+                dataIcon={SquareIcon}
+                showFilter
+                dataFilter={codeFilter}
+                onDataFilterChange={setCodeFilter}
+                expandedItems={expandedCodeIds}
+                onExpandedItemsChange={setExpandedCodeIds}
+                selectedItems={selectedCodeId}
+                onSelectedItemsChange={handleSelectedCodeChange}
+                renderNode={renderNode}
+              />
+            ) : null}
+          </Paper>
+
+          <Stack spacing={2}>
+            <Box>
+              <Typography variant="h6">Assign a shortcut</Typography>
+              <Typography color="text.secondary" variant="body2">
+                Select a code, then choose one of the digit slots below. Changes are saved immediately.
+              </Typography>
+            </Box>
+            <Paper variant="outlined" sx={{ p: 2, minHeight: 64 }}>
+              {selectedCode ? (
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <KeyboardIcon color="action" />
+                  <CodeRenderer code={selectedCode} />
+                </Stack>
+              ) : (
+                <Typography color="text.secondary">No code selected</Typography>
+              )}
+            </Paper>
+            <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 1 }}>
+              {CODE_SHORTCUT_KEYS.map((key) => {
+                const codeId = bindings[key];
+                const code = codeId === undefined ? undefined : codesById.get(codeId);
+                return (
+                  <Paper key={key} variant="outlined" sx={{ display: "flex", alignItems: "center", p: 0.5 }}>
+                    <Button
+                      color="inherit"
+                      disabled={!selectedCode}
+                      onClick={() => handleAssign(key)}
+                      sx={{ flexGrow: 1, justifyContent: "flex-start", minWidth: 0, textTransform: "none" }}
+                    >
+                      <Chip label={key} size="small" sx={{ mr: 1, minWidth: 32 }} />
+                      {code ? (
+                        <Box
+                          sx={{ width: 16, height: 16, bgcolor: code.color, borderRadius: 0.5, mr: 1, flexShrink: 0 }}
+                        />
+                      ) : null}
+                      <Typography noWrap variant="body2">
+                        {code?.name ?? (codeId === undefined ? "Unassigned" : "Unavailable code")}
+                      </Typography>
+                    </Button>
+                    <Tooltip title={`Clear shortcut ${key}`}>
+                      <span>
+                        <IconButton size="small" disabled={codeId === undefined} onClick={() => handleClear(key)}>
+                          <BackspaceIcon fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  </Paper>
+                );
+              })}
+            </Box>
+          </Stack>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="error" onClick={handleClearAll} disabled={CODE_SHORTCUT_KEYS.every((key) => !bindings[key])}>
+          Clear all shortcuts
+        </Button>
+        <Button onClick={close}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/annotation/views/shortcut-dialog/CodeShortcutSynchronizer.tsx
+++ b/frontend/src/features/annotation/views/shortcut-dialog/CodeShortcutSynchronizer.tsx
@@ -1,0 +1,32 @@
+import { CodeHooks } from "@api/hooks/CodeHooks";
+import { useAuth } from "@core/auth";
+import { useAppDispatch, useAppSelector } from "@store/storeHooks";
+import { useEffect } from "react";
+import { CodeShortcutActions } from "../../store/codeShortcutSlice";
+
+interface CodeShortcutSynchronizerProps {
+  projectId: number;
+}
+
+export function CodeShortcutSynchronizer({ projectId }: CodeShortcutSynchronizerProps) {
+  const dispatch = useAppDispatch();
+  const { user } = useAuth();
+  const currentProjectId = useAppSelector((state) => state.project.projectId);
+  const codes = CodeHooks.useGetEnabledCodes();
+
+  useEffect(() => {
+    if (!user || !codes.isSuccess || currentProjectId !== projectId) {
+      return;
+    }
+
+    dispatch(
+      CodeShortcutActions.reconcile({
+        userId: user.id,
+        projectId,
+        validCodeIds: codes.data.map((code) => code.id),
+      }),
+    );
+  }, [codes.data, codes.isSuccess, currentProjectId, dispatch, projectId, user]);
+
+  return null;
+}

--- a/frontend/src/features/annotation/views/shortcut-dialog/index.ts
+++ b/frontend/src/features/annotation/views/shortcut-dialog/index.ts
@@ -1,0 +1,2 @@
+export * from "./CodeShortcutManagerDialog";
+export * from "./CodeShortcutSynchronizer";

--- a/frontend/src/routes/_auth/project/$projectId/route.tsx
+++ b/frontend/src/routes/_auth/project/$projectId/route.tsx
@@ -4,6 +4,7 @@ import { MemoDialog } from "@core/memo";
 import { QuickCommandMenu, ShortcutManager } from "@core/navigation";
 import { ConfirmationDialog } from "@core/notification";
 import { TagCreateDialog, TagEditDialog } from "@core/tag";
+import { CodeShortcutManagerDialog, CodeShortcutSynchronizer } from "@features/annotation";
 // eslint-disable-next-line local/no-internal-modules-public-entry
 import { AnnoActions } from "@features/annotation/store/annoSlice";
 import { ClassifierDialog } from "@features/classifier";
@@ -76,6 +77,8 @@ function ProjectRouteLayout() {
       <FolderEditDialog />
       <CodeCreateDialog projectId={projectId} onCodesCreated={handleCodesCreated} />
       <CodeEditDialog onCodeUpdated={handleCodeUpdated} onCodeDeleted={handleCodeDeleted} />
+      <CodeShortcutManagerDialog projectId={projectId} />
+      <CodeShortcutSynchronizer projectId={projectId} />
       <ConfirmationDialog />
       <ProjectSettingsDialog
         projectId={projectId}

--- a/frontend/src/store/global/dialogBusSlice.ts
+++ b/frontend/src/store/global/dialogBusSlice.ts
@@ -71,6 +71,7 @@ export interface DialogPayloadMap {
   documentUpload: undefined;
   projectSettings: undefined;
   quickCommandMenu: undefined;
+  codeShortcutManager: undefined;
 }
 
 // ─── Callback Registry ────────────────────────────────────────────────────────
@@ -133,6 +134,7 @@ const initialState: DialogBusState = {
   documentUpload: closed,
   projectSettings: closed,
   quickCommandMenu: closed,
+  codeShortcutManager: closed,
 };
 
 // ─── Action payload type ───────────────────────────────────────────────────────

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -9,7 +9,7 @@ import { confirmationReducer, snackbarReducer } from "@core/notification";
 import { seatFilterReducer } from "@core/sentence-annotation";
 import { documentTableFilterReducer } from "@core/source-document";
 import { satFilterReducer } from "@core/span-annotation";
-import { annoReducer } from "@features/annotation";
+import { annoReducer, codeShortcutReducer } from "@features/annotation";
 import { bboxAnnotationAnalysisReducer } from "@features/bbox-annotation-analysis";
 import { classifierReducer } from "@features/classifier";
 import { cotaReducer } from "@features/concept-over-time-analysis";
@@ -34,6 +34,7 @@ export const store = configureStore({
   reducer: {
     // persisted reducers
     ...annoReducer,
+    ...codeShortcutReducer,
     ...searchReducer,
     ...imageSearchReducer,
     ...sentenceSearchReducer,


### PR DESCRIPTION
This PR adds a per-user, per-project “code shortcuts” feature to speed up annotating by letting users bind codes to digit keys (0–9), manage bindings via a new dialog, and use those bindings inside the annotation code picker.

Changes:

- Added a persisted Redux slice for code shortcut bindings (scoped by user + project) and wired it into the global store.
- Introduced a “Code shortcuts” manager dialog (opened from the annotation toolbar) plus a synchronizer to reconcile bindings against currently enabled codes.
- Extended the annotation menu to display shortcut-bound codes prominently and allow digit-key selection.

_You can access a new shortcut manager dialog from the annotation toolbar. Assign codes to the buttons 0-9. Use those assigned shortcuts to quickly select codes in the annotation menu._