### PR TITLE
fixed bug: disabled interactions with fake/pending annotations

### DIFF
--- a/frontend/src/api/hooks/BboxAnnotationHooks.ts
+++ b/frontend/src/api/hooks/BboxAnnotationHooks.ts
@@ -1,14 +1,11 @@
 import { CancelablePromise } from "@api/core/CancelablePromise";
+import { queryClient } from "@api/queryClient";
+import { BboxAnnotationService } from "@api/services/BboxAnnotationService";
 import { BBoxAnnotationCreate } from "@models/BBoxAnnotationCreate";
 import { BBoxAnnotationRead } from "@models/BBoxAnnotationRead";
 import { BBoxAnnotationUpdate } from "@models/BBoxAnnotationUpdate";
-import { UserRead } from "@models/UserRead";
-import { queryClient } from "@api/queryClient";
-import { BboxAnnotationService } from "@api/services/BboxAnnotationService";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { QueryKey } from "./QueryKey";
-
-export const FAKE_BBOX_ID = -1;
 
 // BBOX QUERIES
 const useGetAnnotation = (bboxId: number | undefined) =>
@@ -44,45 +41,18 @@ const useGetBBoxAnnotationsBatch = (sdocId: number | null | undefined, userId: n
   });
 
 // BBOX MUTATIONS
-const useCreateBBoxAnnotation = (user: UserRead | undefined) =>
+const useCreateBBoxAnnotation = () =>
   useMutation({
     mutationFn: (variables: BBoxAnnotationCreate) =>
       BboxAnnotationService.addBboxAnnotation({ requestBody: variables }),
-    // optimistic update:
-    // 1. Cancel any outgoing refetches (so they don't overwrite our optimistic update)
-    // 2. Snapshot the previous value
-    // 3. Optimistically update to the new value
-    // 4. Return a context object with the snapshotted value
-    onMutate: async (newBbox) => {
-      if (!user) return;
-      const affectedQueryKey = [QueryKey.SDOC_BBOX_ANNOTATIONS, newBbox.sdoc_id, user.id];
-      await queryClient.cancelQueries({ queryKey: affectedQueryKey });
-      const previousBboxes = queryClient.getQueryData<BBoxAnnotationRead[]>(affectedQueryKey);
-      const bbox: BBoxAnnotationRead = {
-        ...newBbox,
-        id: FAKE_BBOX_ID,
-        code_id: newBbox.code_id,
-        created: "",
-        updated: "",
-        user_id: user.id,
-        memo_ids: [],
-      };
-      queryClient.setQueryData<BBoxAnnotationRead[]>(affectedQueryKey, (old) => {
-        return old ? [...old, bbox] : [bbox];
-      });
-      return { previousBboxes, affectedQueryKey };
-    },
-    onError: (_error, _newBbox, context) => {
-      // If the mutation fails, use the context returned from onMutate to roll back
-      if (!context) return;
-      queryClient.setQueryData<BBoxAnnotationRead[]>(context.affectedQueryKey, context.previousBboxes);
-    },
     onSuccess: (data) => {
       queryClient.setQueryData<BBoxAnnotationRead>([QueryKey.BBOX_ANNOTATION, data.id], data);
-      // Replace the fake bbox with the real one
       queryClient.setQueryData<BBoxAnnotationRead[]>(
         [QueryKey.SDOC_BBOX_ANNOTATIONS, data.sdoc_id, data.user_id],
-        (old) => (old ? old.map((bbox) => (bbox.id === FAKE_BBOX_ID ? data : bbox)) : [data]),
+        (old) => {
+          if (!old) return [data];
+          return old.some((bbox) => bbox.id === data.id) ? old : [...old, data];
+        },
       );
     },
     meta: {

--- a/frontend/src/api/hooks/SentenceAnnotationHooks.ts
+++ b/frontend/src/api/hooks/SentenceAnnotationHooks.ts
@@ -4,11 +4,8 @@ import { SentenceAnnotationService } from "@api/services/SentenceAnnotationServi
 import { SentenceAnnotationRead } from "@models/SentenceAnnotationRead";
 import { SentenceAnnotationUpdate } from "@models/SentenceAnnotationUpdate";
 import { SentenceAnnotatorResult } from "@models/SentenceAnnotatorResult";
-import { UserRead } from "@models/UserRead";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { QueryKey } from "./QueryKey";
-
-export const FAKE_SENTENCE_ANNOTATION_ID = -1;
 
 // SENTENCE QUERIES
 // TODO: filter out all disabled code ids
@@ -35,48 +32,11 @@ const useGetAnnotation = (sentenceAnnoId: number | undefined) =>
   });
 
 // SENTENCE MUTATIONS
-const useCreateSentenceAnnotation = (user: UserRead | undefined) =>
+const useCreateSentenceAnnotation = () =>
   useMutation({
     mutationFn: SentenceAnnotationService.addSentenceAnnotation,
-    // optimistic update:
-    // 1. Cancel any outgoing refetches (so they don't overwrite our optimistic update)
-    // 2. Snapshot the previous value
-    // 3. Optimistically update to the new value
-    // 4. Return a context object with the snapshotted value
-    onMutate: async ({ requestBody: newSentAnno }) => {
-      if (!user) return;
-      const affectedQueryKey = [QueryKey.SDOC_SENTENCE_ANNOTATOR, newSentAnno.sdoc_id, user.id];
-      await queryClient.cancelQueries({ queryKey: affectedQueryKey });
-      const previousSentenceAnnotator = queryClient.getQueryData<SentenceAnnotatorResult>(affectedQueryKey);
-      const sentAnno: SentenceAnnotationRead = {
-        ...newSentAnno,
-        id: FAKE_SENTENCE_ANNOTATION_ID,
-        user_id: user.id,
-        created: new Date().toISOString(),
-        updated: new Date().toISOString(),
-        memo_ids: [],
-      };
-      queryClient.setQueryData<SentenceAnnotatorResult>(affectedQueryKey, (old) => {
-        if (!old) return old;
-        const sentAnnos = { ...old.sentence_annotations };
-        for (let sentenceId = newSentAnno.sentence_id_start; sentenceId <= newSentAnno.sentence_id_end; sentenceId++) {
-          if (!sentAnnos[sentenceId]) {
-            sentAnnos[sentenceId] = [];
-          }
-          sentAnnos[sentenceId].push(sentAnno);
-        }
-        return { sentence_annotations: sentAnnos };
-      });
-      return { previousSentenceAnnotator, affectedQueryKey };
-    },
-    onError: (_error: Error, _newSentAnnotation, context) => {
-      if (!context) return;
-      // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData<SentenceAnnotatorResult>(context.affectedQueryKey, context.previousSentenceAnnotator);
-    },
     onSuccess: (data) => {
       queryClient.setQueryData<SentenceAnnotationRead>([QueryKey.SENTENCE_ANNOTATION, data.id], data);
-      // Replace the fake sentence annotation with the real one
       queryClient.setQueryData<SentenceAnnotatorResult>(
         [QueryKey.SDOC_SENTENCE_ANNOTATOR, data.sdoc_id, data.user_id],
         (old) => {
@@ -86,9 +46,9 @@ const useCreateSentenceAnnotation = (user: UserRead | undefined) =>
             if (!sentAnnos[sentenceId]) {
               sentAnnos[sentenceId] = [];
             }
-            sentAnnos[sentenceId] = sentAnnos[sentenceId].map((annotation) =>
-              annotation.id === FAKE_SENTENCE_ANNOTATION_ID ? data : annotation,
-            );
+            if (!sentAnnos[sentenceId].some((a) => a.id === data.id)) {
+              sentAnnos[sentenceId] = [...sentAnnos[sentenceId], data];
+            }
           }
           return { sentence_annotations: sentAnnos };
         },
@@ -99,56 +59,28 @@ const useCreateSentenceAnnotation = (user: UserRead | undefined) =>
     },
   });
 
-const useCreateBulkSentenceAnnotation = (user: UserRead | undefined) =>
+const useCreateBulkSentenceAnnotation = () =>
   useMutation({
     mutationFn: SentenceAnnotationService.addSentenceAnnotationsBulk,
-    // optimistic updates
-    onMutate: async ({ requestBody: annotationsToCreate }) => {
-      if (!user) return;
-      if (annotationsToCreate.length === 0) return;
-      const sdocId = annotationsToCreate[0].sdoc_id;
-      if (annotationsToCreate.some((annotation) => annotation.sdoc_id !== sdocId)) {
-        console.error("All annotations to create must belong to the same source document");
-        return;
-      }
-
-      const affectedQueryKey = [QueryKey.SDOC_SENTENCE_ANNOTATOR, sdocId, user.id];
-      await queryClient.cancelQueries({ queryKey: affectedQueryKey });
-      const previousSentenceAnnotator = queryClient.getQueryData<SentenceAnnotatorResult>(affectedQueryKey);
-      let fakeID = FAKE_SENTENCE_ANNOTATION_ID;
-      queryClient.setQueryData<SentenceAnnotatorResult>(affectedQueryKey, (old) => {
+    onSuccess: (data) => {
+      if (data.length === 0) return;
+      const sdocId = data[0].sdoc_id;
+      const userId = data[0].user_id;
+      queryClient.setQueryData<SentenceAnnotatorResult>([QueryKey.SDOC_SENTENCE_ANNOTATOR, sdocId, userId], (old) => {
         if (!old) return old;
         const sentAnnos = { ...old.sentence_annotations };
-        annotationsToCreate.forEach((data) => {
-          const sentAnno: SentenceAnnotationRead = {
-            ...data,
-            id: fakeID,
-            user_id: user.id,
-            created: new Date().toISOString(),
-            updated: new Date().toISOString(),
-            memo_ids: [],
-          };
-          for (let sentenceId = data.sentence_id_start; sentenceId <= data.sentence_id_end; sentenceId++) {
+        data.forEach((annotation) => {
+          for (let sentenceId = annotation.sentence_id_start; sentenceId <= annotation.sentence_id_end; sentenceId++) {
             if (!sentAnnos[sentenceId]) {
               sentAnnos[sentenceId] = [];
             }
-            sentAnnos[sentenceId].push(sentAnno);
+            if (!sentAnnos[sentenceId].some((a) => a.id === annotation.id)) {
+              sentAnnos[sentenceId] = [...sentAnnos[sentenceId], annotation];
+            }
           }
-          fakeID = fakeID - 1;
         });
         return { sentence_annotations: sentAnnos };
       });
-      return { previousSentenceAnnotator, affectedQueryKey };
-    },
-    onError: (_error: Error, _newSentAnnotation, context) => {
-      if (!context) return;
-      // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(context.affectedQueryKey, context.previousSentenceAnnotator);
-    },
-    // Always re-fetch after error or success:
-    onSettled: (_data, _error, _variables, context) => {
-      if (!context) return;
-      queryClient.invalidateQueries({ queryKey: context.affectedQueryKey });
     },
     meta: {
       successMessage: (data: SentenceAnnotationRead[]) => `Created ${data.length} Sentence Annotations`,

--- a/frontend/src/api/hooks/SpanAnnotationHooks.ts
+++ b/frontend/src/api/hooks/SpanAnnotationHooks.ts
@@ -1,14 +1,11 @@
+import { queryClient } from "@api/queryClient";
+import { SpanAnnotationService } from "@api/services/SpanAnnotationService";
 import { SpanAnnotationCreate } from "@models/SpanAnnotationCreate";
 import { SpanAnnotationDeleted } from "@models/SpanAnnotationDeleted";
 import { SpanAnnotationRead } from "@models/SpanAnnotationRead";
 import { SpanAnnotationUpdate } from "@models/SpanAnnotationUpdate";
-import { UserRead } from "@models/UserRead";
-import { queryClient } from "@api/queryClient";
-import { SpanAnnotationService } from "@api/services/SpanAnnotationService";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { QueryKey } from "./QueryKey";
-
-export const FAKE_ANNOTATION_ID = -1;
 
 // SPAN QUERIES
 const useGetAnnotation = (spanId: number | null | undefined) =>
@@ -53,55 +50,18 @@ const useCreateBulkAnnotations = () =>
     },
   });
 
-const useCreateSpanAnnotation = (user: UserRead | undefined) =>
+const useCreateSpanAnnotation = () =>
   useMutation({
     mutationFn: (variables: SpanAnnotationCreate) =>
       SpanAnnotationService.addSpanAnnotation({ requestBody: variables }),
-    // optimistic update:
-    // 1. Cancel any outgoing refetches (so they don't overwrite our optimistic update)
-    // 2. Snapshot the previous value
-    // 3. Optimistically update to the new value
-    // 4. Return a context object with the snapshotted value
-    onMutate: async (newSpanAnnotation) => {
-      if (!user) return;
-      const affectedQueryKey = [QueryKey.SDOC_SPAN_ANNOTATIONS, newSpanAnnotation.sdoc_id, user.id];
-      await queryClient.cancelQueries({ queryKey: affectedQueryKey });
-      const previousSpanAnnotations = queryClient.getQueryData<SpanAnnotationRead[]>(affectedQueryKey);
-      const spanAnno: SpanAnnotationRead = {
-        ...newSpanAnnotation,
-        id: FAKE_ANNOTATION_ID,
-        code_id: newSpanAnnotation.code_id,
-        user_id: user.id,
-        text: "",
-        created: "",
-        updated: "",
-        group_ids: [],
-        memo_ids: [],
-      };
-      queryClient.setQueryData<SpanAnnotationRead[]>(affectedQueryKey, (old) => {
-        // check if there is already a fake annotation, if so, replace it with the new one
-        const fakeAnnotationIndex = old?.findIndex((a) => a.id === FAKE_ANNOTATION_ID);
-        if (fakeAnnotationIndex !== undefined && fakeAnnotationIndex !== -1) {
-          const result = Array.from(old!);
-          result[fakeAnnotationIndex] = spanAnno;
-          return result;
-        }
-        // if there is no fake annotation, add the new one
-        return old ? [...old, spanAnno] : [spanAnno];
-      });
-      return { previousSpanAnnotations, affectedQueryKey };
-    },
-    onError: (_error: Error, _newSpanAnnotation, context) => {
-      if (!context) return;
-      // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData<SpanAnnotationRead[]>(context.affectedQueryKey, context.previousSpanAnnotations);
-    },
     onSuccess: (data) => {
       queryClient.setQueryData<SpanAnnotationRead>([QueryKey.SPAN_ANNOTATION, data.id], data);
-      // Replace the fake span with the real one
       queryClient.setQueryData<SpanAnnotationRead[]>(
         [QueryKey.SDOC_SPAN_ANNOTATIONS, data.sdoc_id, data.user_id],
-        (old) => (old ? old.map((span) => (span.id === FAKE_ANNOTATION_ID ? data : span)) : [data]),
+        (old) => {
+          if (!old) return [data];
+          return old.some((span) => span.id === data.id) ? old : [...old, data];
+        },
       );
     },
     meta: {

--- a/frontend/src/features/annotation/_components/ImageAnnotator.tsx
+++ b/frontend/src/features/annotation/_components/ImageAnnotator.tsx
@@ -6,10 +6,12 @@ import { BboxAnnotationHooks } from "@api/hooks/BboxAnnotationHooks";
 import { MetadataHooks } from "@api/hooks/MetadataHooks";
 import { useAuth } from "@core/auth";
 import { useOpenConfirmationDialog } from "@core/notification";
+import { BBoxAnnotationCreate } from "@models/BBoxAnnotationCreate";
 import { BBoxAnnotationRead } from "@models/BBoxAnnotationRead";
 import { SourceDocumentDataRead } from "@models/SourceDocumentDataRead";
 import { useAppDispatch, useAppSelector } from "@store/storeHooks";
 import { AnnotationRouteAPI } from "../_hooks/annotationRouteAPI";
+import { toPendingBboxAnnotation } from "../_hooks/pendingBboxAnnotation";
 import { useBboxAnnotationResize } from "../_hooks/useBboxAnnotationResize";
 import { Annotation } from "../_types/Annotation";
 import { AnnoActions } from "../store/annoSlice";
@@ -61,13 +63,17 @@ function ImageAnnotatorWithHeight({ sdocData, height }: ImageAnnotatorProps & { 
   // resize controller
   const resizeController = useBboxAnnotationResize(imgRef);
 
-  // computed (filter hidden code ids, apply resize preview override)
+  // annotations already sent to the server but not yet persisted; kept visible until the real
+  // annotation lands in the cache so the highlight never flickers. Keyed by unique negative ids.
+  const [pendingAnnotations, setPendingAnnotations] = useState<BBoxAnnotationRead[]>([]);
+
+  // computed (filter hidden code ids, apply resize preview override, append pending annotations)
   const data = useMemo(() => {
     const filtered = (annotations.data || []).filter((bbox) => !hiddenCodeIds.includes(bbox.code_id));
     const preview = resizeController.previewAnnotation;
-    if (!preview) return filtered;
-    return filtered.map((bbox) => (bbox.id === preview.id ? preview : bbox));
-  }, [annotations.data, hiddenCodeIds, resizeController.previewAnnotation]);
+    const withPreview = preview ? filtered.map((bbox) => (bbox.id === preview.id ? preview : bbox)) : filtered;
+    return pendingAnnotations.length > 0 ? [...withPreview, ...pendingAnnotations] : withPreview;
+  }, [annotations.data, hiddenCodeIds, resizeController.previewAnnotation, pendingAnnotations]);
 
   // local client state
   const [isZooming, setIsZooming] = useState(true);
@@ -76,7 +82,7 @@ function ImageAnnotatorWithHeight({ sdocData, height }: ImageAnnotatorProps & { 
 
   // mutations for create, update, delete
   const { user } = useAuth();
-  const createMutation = BboxAnnotationHooks.useCreateBBoxAnnotation(user);
+  const createMutation = BboxAnnotationHooks.useCreateBBoxAnnotation();
   const updateMutation = BboxAnnotationHooks.useUpdateBBoxAnnotation();
   const deleteMutation = BboxAnnotationHooks.useDeleteBBoxAnnotation();
 
@@ -217,6 +223,17 @@ function ImageAnnotatorWithHeight({ sdocData, height }: ImageAnnotatorProps & { 
     svg.transition().duration(750).call(zoom.transform, d3.zoomIdentity);
   };
 
+  // send a create request and keep the annotation visible (pending) until the real one is cached.
+  const startCreate = (requestBody: BBoxAnnotationCreate, onSuccess?: () => void) => {
+    const pending = toPendingBboxAnnotation(requestBody, user?.id);
+    setPendingAnnotations((prev) => [...prev, pending]);
+    createMutation.mutate(requestBody, {
+      onSuccess,
+      // remove the pending preview once the real annotation is in the cache (or the request failed)
+      onSettled: () => setPendingAnnotations((prev) => prev.filter((a) => a.id !== pending.id)),
+    });
+  };
+
   // code selector events
   const onCodeSelectorAddCode = (codeId: number) => {
     const myRect = d3.select(rectRef.current);
@@ -224,7 +241,7 @@ function ImageAnnotatorWithHeight({ sdocData, height }: ImageAnnotatorProps & { 
     const y = parseInt(myRect.attr("y"));
     const width = parseInt(myRect.attr("width"));
     const height = parseInt(myRect.attr("height"));
-    createMutation.mutate({
+    startCreate({
       code_id: codeId,
       sdoc_id: sdocData.id,
       x_min: x,
@@ -270,7 +287,7 @@ function ImageAnnotatorWithHeight({ sdocData, height }: ImageAnnotatorProps & { 
     if (!isBboxAnnotation(annotationToDuplicate)) {
       return;
     }
-    createMutation.mutate(
+    startCreate(
       {
         code_id: codeId,
         sdoc_id: annotationToDuplicate.sdoc_id,
@@ -279,11 +296,7 @@ function ImageAnnotatorWithHeight({ sdocData, height }: ImageAnnotatorProps & { 
         y_min: annotationToDuplicate.y_min,
         y_max: annotationToDuplicate.y_max,
       },
-      {
-        onSuccess: () => {
-          dispatch(AnnoActions.moveCodeToTop(codeId));
-        },
-      },
+      () => dispatch(AnnoActions.moveCodeToTop(codeId)),
     );
   };
 

--- a/frontend/src/features/annotation/_components/SVGBBox.tsx
+++ b/frontend/src/features/annotation/_components/SVGBBox.tsx
@@ -30,6 +30,9 @@ export const SVGBBox = memo(
   }: SVGBBoxProps & CustomSVGProps) => {
     const code = CodeHooks.useGetCode(bbox.code_id);
 
+    // pending (not yet persisted) annotations have negative ids and never offer resize handles.
+    const isPending = bbox.id < 0;
+
     return (
       <>
         {code.data && (
@@ -46,7 +49,7 @@ export const SVGBBox = memo(
               fill={"transparent"}
               {...props}
             />
-            {onResizeStart && (
+            {onResizeStart && !isPending && (
               <BboxAnnotationResizeHandles
                 bbox={bbox}
                 isHovered={isHovered}

--- a/frontend/src/features/annotation/_components/TextAnnotator.tsx
+++ b/frontend/src/features/annotation/_components/TextAnnotator.tsx
@@ -1,15 +1,13 @@
-import { QueryKey } from "@api/hooks/QueryKey";
-import { FAKE_ANNOTATION_ID, SpanAnnotationHooks } from "@api/hooks/SpanAnnotationHooks";
+import { SpanAnnotationHooks } from "@api/hooks/SpanAnnotationHooks";
 import { useAuth } from "@core/auth";
 import { useOpenConfirmationDialog, useOpenSnackbar } from "@core/notification";
 import { SourceDocumentDataRead } from "@models/SourceDocumentDataRead";
 import { SpanAnnotationCreate } from "@models/SpanAnnotationCreate";
 import { SpanAnnotationRead } from "@models/SpanAnnotationRead";
 import { useAppDispatch, useAppSelector } from "@store/storeHooks";
-import { useQueryClient } from "@tanstack/react-query";
-import { SYSTEM_USER_ID } from "@utils/GlobalConstants";
-import { MouseEvent, MouseEventHandler, useRef, useState } from "react";
+import { MouseEvent, MouseEventHandler, useMemo, useRef, useState } from "react";
 import { AnnotationRouteAPI } from "../_hooks/annotationRouteAPI";
+import { toPendingSpanAnnotation } from "../_hooks/pendingSpanAnnotation";
 import { useComputeTokenData, useTokenData } from "../_hooks/useComputeTokenData";
 import { useSpanAnnotationResize } from "../_hooks/useSpanAnnotationResize";
 import { Annotation } from "../_types/Annotation";
@@ -31,7 +29,12 @@ export function TextAnnotator({ sdocData }: TextAnnotatorProps) {
 
   // local state
   const spanMenuRef = useRef<AnnotationMenuHandle>(null);
-  const [fakeAnnotation, setFakeAnnotation] = useState<SpanAnnotationCreate | undefined>(undefined);
+  // the draft annotation whose code-selector menu is currently open (not yet sent to the server).
+  // Rendered as a preview via its negative pending id.
+  const [draftAnnotation, setDraftAnnotation] = useState<SpanAnnotationRead | undefined>(undefined);
+  // annotations already sent to the server but not yet persisted; kept visible until the real
+  // annotation lands in the cache so the highlight never flickers. Keyed by unique negative ids.
+  const [pendingAnnotations, setPendingAnnotations] = useState<SpanAnnotationRead[]>([]);
 
   // global client state (URL search params)
   const { visibleUserId } = AnnotationRouteAPI.useSearch();
@@ -45,6 +48,12 @@ export function TextAnnotator({ sdocData }: TextAnnotatorProps) {
   // snackbar
   const openSnackbar = useOpenSnackbar();
 
+  // the draft (menu open) is rendered as a preview alongside the in-flight pending annotations
+  const allPendingAnnotations = useMemo<SpanAnnotationRead[]>(
+    () => (draftAnnotation ? [...pendingAnnotations, draftAnnotation] : pendingAnnotations),
+    [pendingAnnotations, draftAnnotation],
+  );
+
   // computed / custom hooks
   const resizeTokenData = useTokenData(sdocData);
   const resizeController = useSpanAnnotationResize(resizeTokenData);
@@ -52,11 +61,11 @@ export function TextAnnotator({ sdocData }: TextAnnotatorProps) {
     sdocData,
     userId: visibleUserId,
     annotationOverride: resizeController.previewAnnotation,
+    pendingAnnotations: allPendingAnnotations,
   });
 
   // mutations for create, update, delete
-  const queryClient = useQueryClient();
-  const createMutation = SpanAnnotationHooks.useCreateSpanAnnotation(user);
+  const createMutation = SpanAnnotationHooks.useCreateSpanAnnotation();
   const updateMutation = SpanAnnotationHooks.useUpdateSpanAnnotation();
   const deleteMutation = SpanAnnotationHooks.useDeleteSpanAnnotation();
 
@@ -104,7 +113,7 @@ export function TextAnnotator({ sdocData }: TextAnnotatorProps) {
     }
   };
 
-  const handleMouseUp = async (event: MouseEvent) => {
+  const handleMouseUp = (event: MouseEvent) => {
     if (resizeController.shouldIgnoreMouseUp()) return;
     if (event.button === 2) return;
     if (!tokenData) return;
@@ -175,31 +184,8 @@ export function TextAnnotator({ sdocData }: TextAnnotatorProps) {
       span_text: span_text,
     };
 
-    // create a fake annotation
-    setFakeAnnotation(requestBody);
-
-    // when we create a new span annotation, we add a new annotation to a certain document
-    // thus, we only affect the annotation document that we are adding to
-    const affectedQueryKey = [QueryKey.SDOC_SPAN_ANNOTATIONS, requestBody.sdoc_id, visibleUserId];
-
-    // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
-    await queryClient.cancelQueries({ queryKey: affectedQueryKey });
-
-    // Add a fake annotation
-    queryClient.setQueryData<SpanAnnotationRead[]>(affectedQueryKey, (old) => {
-      const spanAnnotation: SpanAnnotationRead = {
-        ...requestBody,
-        id: FAKE_ANNOTATION_ID,
-        text: requestBody.span_text,
-        code_id: requestBody.code_id,
-        created: "",
-        updated: "",
-        user_id: user?.id || SYSTEM_USER_ID,
-        group_ids: [],
-        memo_ids: [],
-      };
-      return old === undefined ? [spanAnnotation] : [...old, spanAnnotation];
-    });
+    // store the draft annotation in local state; it is rendered via the pendingAnnotations override
+    setDraftAnnotation(toPendingSpanAnnotation(requestBody, user?.id));
 
     // open code selector
     const target = selectionStartElement;
@@ -238,26 +224,38 @@ export function TextAnnotator({ sdocData }: TextAnnotatorProps) {
       },
     });
   };
+  // send a create request and keep the annotation visible (pending) until the real one is cached.
+  // `pending` is the local preview annotation; only its create-payload fields are sent to the server.
+  const startCreate = (pending: SpanAnnotationRead, codeId: number, onSuccess?: () => void) => {
+    const requestBody: SpanAnnotationCreate = {
+      code_id: codeId,
+      sdoc_id: pending.sdoc_id,
+      begin: pending.begin,
+      end: pending.end,
+      begin_token: pending.begin_token,
+      end_token: pending.end_token,
+      span_text: pending.text,
+    };
+    setPendingAnnotations((prev) => [...prev, { ...pending, code_id: codeId }]);
+    createMutation.mutate(requestBody, {
+      onSuccess,
+      // remove the pending preview once the real annotation is in the cache (or the request failed)
+      onSettled: () => setPendingAnnotations((prev) => prev.filter((a) => a.id !== pending.id)),
+    });
+  };
+
   const handleCodeSelectorAddCode = (codeId: number, isNewCode: boolean) => {
-    if (!fakeAnnotation) return;
-    createMutation.mutate(
-      {
-        ...fakeAnnotation,
-        code_id: codeId,
-      },
-      {
-        onSuccess: () => {
-          if (!isNewCode) {
-            // if we use an existing code to annotate, we move it to the top
-            dispatch(AnnoActions.moveCodeToTop(codeId));
-          }
-        },
-      },
-    );
+    if (!draftAnnotation) return;
+    startCreate(draftAnnotation, codeId, () => {
+      if (!isNewCode) {
+        // if we use an existing code to annotate, we move it to the top
+        dispatch(AnnoActions.moveCodeToTop(codeId));
+      }
+    });
   };
   const handleCodeSelectorDuplicateAnnotation = (annotation: Annotation, codeId: number) => {
     if ("id" in annotation && "begin_token" in annotation && "end_token" in annotation) {
-      const fakeAnnotation: SpanAnnotationCreate = {
+      const requestBody: SpanAnnotationCreate = {
         begin: annotation.begin,
         end: annotation.end,
         begin_token: annotation.begin_token,
@@ -266,38 +264,22 @@ export function TextAnnotator({ sdocData }: TextAnnotatorProps) {
         sdoc_id: annotation.sdoc_id,
         code_id: codeId,
       };
-      createMutation.mutate(fakeAnnotation, {
-        onSuccess: () => {
-          dispatch(AnnoActions.moveCodeToTop(codeId));
-        },
-      });
+      const pending = toPendingSpanAnnotation(requestBody, user?.id);
+      startCreate(pending, codeId, () => dispatch(AnnoActions.moveCodeToTop(codeId)));
     }
   };
   const handleCodeSelectorClose = (reason?: "backdropClick" | "escapeKeyDown") => {
     // i am about to create an annotation
-    if (fakeAnnotation) {
+    if (draftAnnotation) {
       // i clicked away because i like the annotation as is
       if (reason === "backdropClick") {
         // add the annotation as is
-        createMutation.mutate(
-          { ...fakeAnnotation },
-          {
-            onSuccess: () => {
-              dispatch(AnnoActions.moveCodeToTop(fakeAnnotation.code_id));
-            },
-          },
-        );
-      }
-      // i clicked escape because i want to cancel the annotation
-      if (reason === "escapeKeyDown") {
-        // delete the fake annotation (that always has id -1)
-        queryClient.setQueryData<SpanAnnotationRead[]>(
-          [QueryKey.SDOC_SPAN_ANNOTATIONS, fakeAnnotation.sdoc_id, visibleUserId],
-          (old) => old?.filter((spanAnnotation) => spanAnnotation.id !== -1),
+        startCreate(draftAnnotation, draftAnnotation.code_id, () =>
+          dispatch(AnnoActions.moveCodeToTop(draftAnnotation.code_id)),
         );
       }
     }
-    setFakeAnnotation(undefined);
+    setDraftAnnotation(undefined);
   };
 
   return (

--- a/frontend/src/features/annotation/_components/_components/CodeIndicator.tsx
+++ b/frontend/src/features/annotation/_components/_components/CodeIndicator.tsx
@@ -35,6 +35,10 @@ export function CodeIndicator({
   const code = CodeHooks.useGetCode(codeId);
   const openMemoDialog = useOpenMemoDialog();
 
+  // pending (not yet persisted) annotations have negative ids. They render their real code pill
+  // (so the label never flickers), but are styled as pending and made non-interactive until saved.
+  const isPending = annotationId < 0;
+
   const handleMemoClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     openMemoDialog({
@@ -58,7 +62,8 @@ export function CodeIndicator({
     return (
       <span
         id={"span-annotation-" + annotationId}
-        className={`code-indicator ${isSelected ? "code-indicator--selected" : ""}`}
+        className={`code-indicator ${isSelected ? "code-indicator--selected" : ""} ${isPending ? "code-indicator--pending" : ""}`}
+        title={isPending ? "Saving annotation…" : undefined}
         style={
           {
             "--indicator-color": color,
@@ -67,7 +72,7 @@ export function CodeIndicator({
       >
         <span className="code-indicator__color-dot" />
         <span className="code-indicator__text">{text}</span>
-        {memoCount > 0 && (
+        {memoCount > 0 && !isPending && (
           <span className="code-indicator__memo" onClick={handleMemoClick} title="Has memo — click to open">
             {getIconComponent(Icon.MEMO_ALT, { style: { fontSize: "inherit" } })}
             <span className="code-indicator__memo-count">{memoCount}</span>

--- a/frontend/src/features/annotation/_components/_components/Mark.tsx
+++ b/frontend/src/features/annotation/_components/_components/Mark.tsx
@@ -15,28 +15,32 @@ interface MarkProps {
 export function Mark({ annotation, isStart, isEnd, height, top, onResizeStart }: MarkProps) {
   const code = CodeHooks.useGetCode(annotation.code_id);
 
-  const resizeHandles = onResizeStart ? (
-    <>
-      {isStart && (
-        <span
-          className="span-resize-handle span-resize-handle--start"
-          data-span-resize-handle
-          onPointerDown={(event) => onResizeStart(annotation, "start", event)}
-          onClick={(event) => event.stopPropagation()}
-          onMouseUp={(event) => event.stopPropagation()}
-        />
-      )}
-      {isEnd && (
-        <span
-          className="span-resize-handle span-resize-handle--end"
-          data-span-resize-handle
-          onPointerDown={(event) => onResizeStart(annotation, "end", event)}
-          onClick={(event) => event.stopPropagation()}
-          onMouseUp={(event) => event.stopPropagation()}
-        />
-      )}
-    </>
-  ) : null;
+  // pending (not yet persisted) annotations have negative ids and never offer resize handles.
+  const isPending = annotation.id < 0;
+
+  const resizeHandles =
+    onResizeStart && !isPending ? (
+      <>
+        {isStart && (
+          <span
+            className="span-resize-handle span-resize-handle--start"
+            data-span-resize-handle
+            onPointerDown={(event) => onResizeStart(annotation, "start", event)}
+            onClick={(event) => event.stopPropagation()}
+            onMouseUp={(event) => event.stopPropagation()}
+          />
+        )}
+        {isEnd && (
+          <span
+            className="span-resize-handle span-resize-handle--end"
+            data-span-resize-handle
+            onPointerDown={(event) => onResizeStart(annotation, "end", event)}
+            onClick={(event) => event.stopPropagation()}
+            onMouseUp={(event) => event.stopPropagation()}
+          />
+        )}
+      </>
+    ) : null;
 
   if (code.data) {
     let color: string;

--- a/frontend/src/features/annotation/_components/_styles/Annotation.css
+++ b/frontend/src/features/annotation/_components/_styles/Annotation.css
@@ -163,6 +163,25 @@ A code indicator (.code-indicator) can be selected (code-indicator--selected) an
     0 2px 8px color-mix(in srgb, var(--indicator-color) 30%, transparent);
 }
 
+/* A pending (not yet persisted) annotation: keeps its real code color, but is dashed,
+   non-interactive, and gently pulses until it has been saved. */
+.code-indicator--pending {
+  border-style: dashed;
+  cursor: default;
+  pointer-events: none;
+  animation: code-indicator-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes code-indicator-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
 /*
 MARKER: Mark.tsx
 This is the styling of the "background" marks that indicate the span boundaries.

--- a/frontend/src/features/annotation/_components/sentence-annotator/_hooks/useGetSentenceAnnotator.ts
+++ b/frontend/src/features/annotation/_components/sentence-annotator/_hooks/useGetSentenceAnnotator.ts
@@ -31,6 +31,8 @@ export interface UseGetSentenceAnnotator {
  * @param userId - The user whose annotations to fetch
  * @param annotationOverride - Optional annotation to substitute in the data
  *   before computing lanes (used for live preview during resize drags)
+ * @param pendingAnnotations - Optional pending annotations (not yet persisted)
+ *   to include in the lane computation (rendered from local state only)
  * @returns The raw annotator result, the (possibly overridden) per-sentence
  *   annotations, per-sentence lane maps (position → annotation ID), and the
  *   maximum lane index used
@@ -39,51 +41,76 @@ export function useGetSentenceAnnotator({
   sdocId,
   userId,
   annotationOverride,
+  pendingAnnotations,
 }: {
   sdocId: number;
   userId: number | undefined;
   annotationOverride?: SentenceAnnotationRead;
+  pendingAnnotations?: SentenceAnnotationRead[];
 }): UseGetSentenceAnnotator {
   const annotatorResult = SentenceAnnotationHooks.useGetSentenceAnnotator(sdocId, userId);
+
+  // Three-layer memoization to avoid recomputing lane assignments on every change:
+  // 1. Base sentence annotations from server data (rare changes)
+  // 2. + pending annotations (rare changes, purely additive)
+  // 3. + annotation override (frequent during resize drag, targeted patch)
+
+  // Layer 1: extract base sentence annotations from server data
+  const baseSentenceAnnotations = useMemo(() => {
+    if (!annotatorResult.data?.sentence_annotations) return undefined;
+    const values = Object.values(annotatorResult.data.sentence_annotations);
+    return values.length > 0 ? values : undefined;
+  }, [annotatorResult.data]);
+
+  // Layer 2: patch pending annotations on top (purely additive, short-circuits when empty)
+  const withPendings = useMemo(() => {
+    if (!baseSentenceAnnotations) return baseSentenceAnnotations;
+    if (!pendingAnnotations || pendingAnnotations.length === 0) return baseSentenceAnnotations;
+
+    const result = baseSentenceAnnotations.map((annotations) => [...annotations]);
+    pendingAnnotations.forEach((pending) => {
+      for (let i = pending.sentence_id_start; i <= pending.sentence_id_end; i++) {
+        if (!result[i]) result[i] = [];
+        result[i].push(pending);
+      }
+    });
+    return result;
+  }, [baseSentenceAnnotations, pendingAnnotations]);
+
+  // Layer 3: patch the resize override on top (short-circuits when idle)
+  const withOverride = useMemo(() => {
+    if (!withPendings) return withPendings;
+    if (!annotationOverride) return withPendings;
+
+    const override = annotationOverride;
+    return withPendings.map((annotations, sentenceIndex) => {
+      const coversSentence = override.sentence_id_start <= sentenceIndex && sentenceIndex <= override.sentence_id_end;
+      const isListed = annotations.some((a) => a.id === override.id);
+      if (coversSentence && !isListed) return [...annotations, override];
+      if (!coversSentence && isListed) return annotations.filter((a) => a.id !== override.id);
+      if (isListed) return annotations.map((a) => (a.id === override.id ? override : a));
+      return annotations;
+    });
+  }, [withPendings, annotationOverride]);
+
+  // Compute lane assignments from the final sentence annotations
   const {
     sentenceAnnotations: overriddenSentenceAnnotations,
     annotationPositions,
     numPositions,
   } = useMemo(() => {
-    if (!annotatorResult.data?.sentence_annotations)
+    if (!withOverride)
       return {
         sentenceAnnotations: {} as Record<number, SentenceAnnotationRead[]>,
         annotationPositions: [],
         numPositions: 0,
       };
-    let sentenceAnnotations = Object.values(annotatorResult.data.sentence_annotations);
-
-    if (sentenceAnnotations.length === 0)
-      return {
-        sentenceAnnotations: {} as Record<number, SentenceAnnotationRead[]>,
-        annotationPositions: [],
-        numPositions: 0,
-      };
-
-    // apply the annotation override (e.g. preview during resize) so that lane
-    // assignment reflects the override's boundaries
-    if (annotationOverride) {
-      const override = annotationOverride;
-      sentenceAnnotations = sentenceAnnotations.map((annotations, sentenceIndex) => {
-        const coversSentence = override.sentence_id_start <= sentenceIndex && sentenceIndex <= override.sentence_id_end;
-        const isListed = annotations.some((a) => a.id === override.id);
-        if (coversSentence && !isListed) return [...annotations, override];
-        if (!coversSentence && isListed) return annotations.filter((a) => a.id !== override.id);
-        if (isListed) return annotations.map((a) => (a.id === override.id ? override : a));
-        return annotations;
-      });
-    }
 
     // collect unique annotations (the backend includes each annotation once per covered sentence)
     // and sort them by (start, end, id) so that lane assignment is deterministic:
     // annotations that start earlier always get lower lanes
     const seen = new Set<number>();
-    const allAnnotations = sentenceAnnotations.flat().filter((a) => {
+    const allAnnotations = withOverride.flat().filter((a) => {
       if (seen.has(a.id)) return false;
       seen.add(a.id);
       return true;
@@ -108,7 +135,7 @@ export function useGetSentenceAnnotator({
 
     // build per-sentence position maps (key: position, value: annotation id)
     let numPositions = 0;
-    const annotationPositions: Record<number, number>[] = sentenceAnnotations.map((annotations) => {
+    const annotationPositions: Record<number, number>[] = withOverride.map((annotations) => {
       const positions: Record<number, number> = {};
       for (const annotation of annotations) {
         const lane = laneByAnnotationId.get(annotation.id);
@@ -122,12 +149,12 @@ export function useGetSentenceAnnotator({
 
     // build the overridden sentence annotations record (sentence index → annotations)
     const sentenceAnnotationsRecord: Record<number, SentenceAnnotationRead[]> = {};
-    sentenceAnnotations.forEach((annotations, index) => {
+    withOverride.forEach((annotations, index) => {
       sentenceAnnotationsRecord[index] = annotations;
     });
 
     return { sentenceAnnotations: sentenceAnnotationsRecord, annotationPositions, numPositions };
-  }, [annotatorResult.data, annotationOverride]);
+  }, [withOverride]);
 
   return {
     annotatorResult: annotatorResult.data,

--- a/frontend/src/features/annotation/_components/sentence-annotator/annotator/SentenceAnnotator.tsx
+++ b/frontend/src/features/annotation/_components/sentence-annotator/annotator/SentenceAnnotator.tsx
@@ -8,7 +8,9 @@ import { memo, useMemo, useRef, useState } from "react";
 
 import { SentenceAnnotationHooks } from "@api/hooks/SentenceAnnotationHooks";
 import { useAuth } from "@core/auth";
+import { SentenceAnnotationCreate } from "@models/SentenceAnnotationCreate";
 import { AnnotationRouteAPI } from "../../../_hooks/annotationRouteAPI";
+import { toPendingSentenceAnnotation } from "../../../_hooks/pendingSentenceAnnotation";
 import { useSentenceAnnotationResize } from "../../../_hooks/useSentenceAnnotationResize";
 import { Annotation } from "../../../_types/Annotation";
 import { AnnoActions } from "../../../store/annoSlice";
@@ -43,11 +45,14 @@ export const SentenceAnnotator = memo(
     const hoveredCodeId = useAppSelector((state) => state.annotations.hoveredCodeId);
     const [hoverSentAnnoId, setHoverSentAnnoId] = useState<number | null>(null);
 
+    // pending annotations (not yet persisted, rendered from local state only)
+    const [pendingAnnotations, setPendingAnnotations] = useState<SentenceAnnotationRead[]>([]);
+
     // annotation menu
     const annotationMenuRef = useRef<AnnotationMenuHandle>(null);
     const dispatch = useAppDispatch();
     const { user } = useAuth();
-    const createMutation = SentenceAnnotationHooks.useCreateSentenceAnnotation(user);
+    const createMutation = SentenceAnnotationHooks.useCreateSentenceAnnotation();
     const deleteMutation = SentenceAnnotationHooks.useDeleteSentenceAnnotation();
     const updateMutation = SentenceAnnotationHooks.useUpdateSentenceAnnotation();
 
@@ -61,6 +66,7 @@ export const SentenceAnnotator = memo(
       sdocId: sdocData.id,
       userId: visibleUserId,
       annotationOverride: previewAnnotation,
+      pendingAnnotations,
     });
 
     const handleCodeSelectorDeleteAnnotation = (annotation: Annotation) => {
@@ -74,25 +80,34 @@ export const SentenceAnnotator = memo(
         },
       });
     };
+    const startCreate = (requestBody: SentenceAnnotationCreate, onSuccess?: () => void) => {
+      const pending = toPendingSentenceAnnotation(requestBody, user?.id);
+      setPendingAnnotations((prev) => [...prev, pending]);
+      createMutation.mutate(
+        { requestBody },
+        {
+          onSuccess,
+          onSettled: () => {
+            setPendingAnnotations((prev) => prev.filter((a) => a.id !== pending.id));
+          },
+        },
+      );
+    };
     const handleCodeSelectorAddCode = (codeId: number, isNewCode: boolean) => {
       setSelectedSentences([]);
       setLastClickedIndex(null);
-      createMutation.mutate(
+      startCreate(
         {
-          requestBody: {
-            code_id: codeId,
-            sdoc_id: sdocData.id,
-            sentence_id_start: selectedSentences[0],
-            sentence_id_end: selectedSentences[selectedSentences.length - 1],
-          },
+          code_id: codeId,
+          sdoc_id: sdocData.id,
+          sentence_id_start: selectedSentences[0],
+          sentence_id_end: selectedSentences[selectedSentences.length - 1],
         },
-        {
-          onSuccess: () => {
-            if (!isNewCode) {
-              // if we use an existing code to annotate, we move it to the top
-              dispatch(AnnoActions.moveCodeToTop(codeId));
-            }
-          },
+        () => {
+          if (!isNewCode) {
+            // if we use an existing code to annotate, we move it to the top
+            dispatch(AnnoActions.moveCodeToTop(codeId));
+          }
         },
       );
     };
@@ -100,32 +115,26 @@ export const SentenceAnnotator = memo(
       if (!isSentenceAnnotation(annotation)) {
         return;
       }
-      createMutation.mutate(
+      startCreate(
         {
-          requestBody: {
-            code_id: codeId,
-            sdoc_id: annotation.sdoc_id,
-            sentence_id_start: annotation.sentence_id_start,
-            sentence_id_end: annotation.sentence_id_end,
-          },
+          code_id: codeId,
+          sdoc_id: annotation.sdoc_id,
+          sentence_id_start: annotation.sentence_id_start,
+          sentence_id_end: annotation.sentence_id_end,
         },
-        {
-          onSuccess: () => {
-            dispatch(AnnoActions.moveCodeToTop(codeId));
-          },
+        () => {
+          dispatch(AnnoActions.moveCodeToTop(codeId));
         },
       );
     };
     const handleCodeSelectorClose = (reason?: "backdropClick" | "escapeKeyDown") => {
       // i clicked away because i like the annotation as is
       if (selectedSentences.length > 0 && reason === "backdropClick" && mostRecentCodeId) {
-        createMutation.mutate({
-          requestBody: {
-            code_id: mostRecentCodeId,
-            sdoc_id: sdocData.id,
-            sentence_id_start: selectedSentences[0],
-            sentence_id_end: selectedSentences[selectedSentences.length - 1],
-          },
+        startCreate({
+          code_id: mostRecentCodeId,
+          sdoc_id: sdocData.id,
+          sentence_id_start: selectedSentences[0],
+          sentence_id_end: selectedSentences[selectedSentences.length - 1],
         });
       }
       // i clicked escape because i want to cancel the annotation

--- a/frontend/src/features/annotation/_components/sentence-annotator/comparator/SentenceAnnotationComparison.tsx
+++ b/frontend/src/features/annotation/_components/sentence-annotator/comparator/SentenceAnnotationComparison.tsx
@@ -40,6 +40,9 @@ export const SentenceAnnotationComparison = memo(
     const leftResizeController = useSentenceAnnotationResize(sdocData.sentences.length);
     const rightResizeController = useSentenceAnnotationResize(sdocData.sentences.length);
 
+    // pending annotations (not yet persisted, rendered from local state only)
+    const [pendingAnnotations, setPendingAnnotations] = useState<SentenceAnnotationRead[]>([]);
+
     // global server state (react-query)
     const codeMap = CodeHooks.useGetAllCodesMap();
     const annotatorLeft = useGetSentenceAnnotator({
@@ -63,9 +66,6 @@ export const SentenceAnnotationComparison = memo(
     // highlighting
     const hoveredCodeId = useAppSelector((state) => state.annotations.hoveredCodeId);
     const [hoverSentAnnoId, setHoverSentAnnoId] = useState<number | null>(null);
-
-    // pending annotations (not yet persisted, rendered from local state only)
-    const [pendingAnnotations, setPendingAnnotations] = useState<SentenceAnnotationRead[]>([]);
 
     // annotation menu
     const annotationMenuRef = useRef<AnnotationMenuHandle>(null);

--- a/frontend/src/features/annotation/_components/sentence-annotator/comparator/SentenceAnnotationComparison.tsx
+++ b/frontend/src/features/annotation/_components/sentence-annotator/comparator/SentenceAnnotationComparison.tsx
@@ -1,6 +1,7 @@
 import { CodeHooks } from "@api/hooks/CodeHooks";
 import { SentenceAnnotationHooks } from "@api/hooks/SentenceAnnotationHooks";
 import { useAuth } from "@core/auth";
+import { SentenceAnnotationCreate } from "@models/SentenceAnnotationCreate";
 import { SentenceAnnotationRead } from "@models/SentenceAnnotationRead";
 import { SourceDocumentDataRead } from "@models/SourceDocumentDataRead";
 import { Box, BoxProps } from "@mui/material";
@@ -8,6 +9,7 @@ import { useAppDispatch, useAppSelector } from "@store/storeHooks";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { memo, useMemo, useRef, useState } from "react";
 import { AnnotationRouteAPI } from "../../../_hooks/annotationRouteAPI";
+import { toPendingSentenceAnnotation } from "../../../_hooks/pendingSentenceAnnotation";
 import { useSentenceAnnotationResize } from "../../../_hooks/useSentenceAnnotationResize";
 import { Annotation } from "../../../_types/Annotation";
 import { AnnoActions } from "../../../store/annoSlice";
@@ -44,6 +46,7 @@ export const SentenceAnnotationComparison = memo(
       sdocId: sdocData.id,
       userId: leftUserId,
       annotationOverride: leftResizeController.previewAnnotation,
+      pendingAnnotations,
     });
     const annotatorRight = useGetSentenceAnnotator({
       sdocId: sdocData.id,
@@ -61,11 +64,14 @@ export const SentenceAnnotationComparison = memo(
     const hoveredCodeId = useAppSelector((state) => state.annotations.hoveredCodeId);
     const [hoverSentAnnoId, setHoverSentAnnoId] = useState<number | null>(null);
 
+    // pending annotations (not yet persisted, rendered from local state only)
+    const [pendingAnnotations, setPendingAnnotations] = useState<SentenceAnnotationRead[]>([]);
+
     // annotation menu
     const annotationMenuRef = useRef<AnnotationMenuHandle>(null);
     const dispatch = useAppDispatch();
-    const createMutation = SentenceAnnotationHooks.useCreateSentenceAnnotation(user);
-    const createBulkMutation = SentenceAnnotationHooks.useCreateBulkSentenceAnnotation(user);
+    const createMutation = SentenceAnnotationHooks.useCreateSentenceAnnotation();
+    const createBulkMutation = SentenceAnnotationHooks.useCreateBulkSentenceAnnotation();
     const deleteMutation = SentenceAnnotationHooks.useDeleteSentenceAnnotation();
     const deleteBulkMutation = SentenceAnnotationHooks.useDeleteBulkSentenceAnnotationSingleSdoc();
     const updateMutation = SentenceAnnotationHooks.useUpdateSentenceAnnotation();
@@ -80,25 +86,34 @@ export const SentenceAnnotationComparison = memo(
         },
       });
     };
+    const startCreate = (requestBody: SentenceAnnotationCreate, onSuccess?: () => void) => {
+      const pending = toPendingSentenceAnnotation(requestBody, user?.id);
+      setPendingAnnotations((prev) => [...prev, pending]);
+      createMutation.mutate(
+        { requestBody },
+        {
+          onSuccess,
+          onSettled: () => {
+            setPendingAnnotations((prev) => prev.filter((a) => a.id !== pending.id));
+          },
+        },
+      );
+    };
     const handleCodeSelectorAddCode = (codeId: number, isNewCode: boolean) => {
       setSelectedSentences([]);
       setLastClickedIndex(null);
-      createMutation.mutate(
+      startCreate(
         {
-          requestBody: {
-            code_id: codeId,
-            sdoc_id: sdocData.id,
-            sentence_id_start: selectedSentences[0],
-            sentence_id_end: selectedSentences[selectedSentences.length - 1],
-          },
+          code_id: codeId,
+          sdoc_id: sdocData.id,
+          sentence_id_start: selectedSentences[0],
+          sentence_id_end: selectedSentences[selectedSentences.length - 1],
         },
-        {
-          onSuccess: () => {
-            if (!isNewCode) {
-              // if we use an existing code to annotate, we move it to the top
-              dispatch(AnnoActions.moveCodeToTop(codeId));
-            }
-          },
+        () => {
+          if (!isNewCode) {
+            // if we use an existing code to annotate, we move it to the top
+            dispatch(AnnoActions.moveCodeToTop(codeId));
+          }
         },
       );
     };
@@ -106,32 +121,26 @@ export const SentenceAnnotationComparison = memo(
       if (!isSentenceAnnotation(annotation)) {
         return;
       }
-      createMutation.mutate(
+      startCreate(
         {
-          requestBody: {
-            code_id: codeId,
-            sdoc_id: annotation.sdoc_id,
-            sentence_id_start: annotation.sentence_id_start,
-            sentence_id_end: annotation.sentence_id_end,
-          },
+          code_id: codeId,
+          sdoc_id: annotation.sdoc_id,
+          sentence_id_start: annotation.sentence_id_start,
+          sentence_id_end: annotation.sentence_id_end,
         },
-        {
-          onSuccess: () => {
-            dispatch(AnnoActions.moveCodeToTop(codeId));
-          },
+        () => {
+          dispatch(AnnoActions.moveCodeToTop(codeId));
         },
       );
     };
     const handleCodeSelectorClose = (reason?: "backdropClick" | "escapeKeyDown") => {
       // i clicked away because i like the annotation as is
       if (selectedSentences.length > 0 && reason === "backdropClick" && mostRecentCodeId) {
-        createMutation.mutate({
-          requestBody: {
-            code_id: mostRecentCodeId,
-            sdoc_id: sdocData.id,
-            sentence_id_start: selectedSentences[0],
-            sentence_id_end: selectedSentences[selectedSentences.length - 1],
-          },
+        startCreate({
+          code_id: mostRecentCodeId,
+          sdoc_id: sdocData.id,
+          sentence_id_start: selectedSentences[0],
+          sentence_id_end: selectedSentences[selectedSentences.length - 1],
         });
       }
       // i clicked escape because i want to cancel the annotation

--- a/frontend/src/features/annotation/_components/span-annotation-comparator/SpanAnnotationComparator.tsx
+++ b/frontend/src/features/annotation/_components/span-annotation-comparator/SpanAnnotationComparator.tsx
@@ -1,7 +1,5 @@
 import { CodeHooks } from "@api/hooks/CodeHooks";
-import { QueryKey } from "@api/hooks/QueryKey";
-import { FAKE_ANNOTATION_ID, SpanAnnotationHooks } from "@api/hooks/SpanAnnotationHooks";
-import { queryClient } from "@api/queryClient";
+import { SpanAnnotationHooks } from "@api/hooks/SpanAnnotationHooks";
 import { useAuth } from "@core/auth";
 import { useOpenConfirmationDialog, useOpenSnackbar } from "@core/notification";
 import { UserRenderer } from "@core/user";
@@ -11,9 +9,9 @@ import { SpanAnnotationRead } from "@models/SpanAnnotationRead";
 import { Box, BoxProps, Button, Stack, Typography } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "@store/storeHooks";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { SYSTEM_USER_ID } from "@utils/GlobalConstants";
 import { memo, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnnotationRouteAPI } from "../../_hooks/annotationRouteAPI";
+import { toPendingSpanAnnotation } from "../../_hooks/pendingSpanAnnotation";
 import { useComputeTokenData, useTokenData } from "../../_hooks/useComputeTokenData";
 import { useSpanAnnotationResize } from "../../_hooks/useSpanAnnotationResize";
 import { Annotation } from "../../_types/Annotation";
@@ -74,7 +72,7 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // Mutator hooks for span annotations
-  const createMutation = SpanAnnotationHooks.useCreateSpanAnnotation(user);
+  const createMutation = SpanAnnotationHooks.useCreateSpanAnnotation();
   const createBulkMutation = SpanAnnotationHooks.useCreateBulkAnnotations();
   const updateMutation = SpanAnnotationHooks.useUpdateSpanAnnotation();
   const deleteMutation = SpanAnnotationHooks.useDeleteSpanAnnotation();
@@ -84,6 +82,19 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
   const resizeTokenData = useTokenData(sdocData);
   const leftResizeController = useSpanAnnotationResize(resizeTokenData);
   const rightResizeController = useSpanAnnotationResize(resizeTokenData);
+  // the draft annotation whose code-selector menu is currently open in the left panel (not yet sent).
+  // Rendered as a preview via its negative pending id.
+  const [draftAnnotation, setDraftAnnotation] = useState<SpanAnnotationRead | undefined>(undefined);
+  // annotations already sent to the server but not yet persisted; kept visible until the real
+  // annotation lands in the cache so the highlight never flickers. Keyed by unique negative ids.
+  const [pendingAnnotations, setPendingAnnotations] = useState<SpanAnnotationRead[]>([]);
+
+  // the draft (menu open) is rendered as a preview alongside the in-flight pending annotations
+  const allPendingAnnotations = useMemo<SpanAnnotationRead[]>(
+    () => (draftAnnotation ? [...pendingAnnotations, draftAnnotation] : pendingAnnotations),
+    [pendingAnnotations, draftAnnotation],
+  );
+
   const {
     tokenData: leftTokenData,
     annotationsPerToken: leftAnnotationsPerToken,
@@ -92,6 +103,7 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
     sdocData,
     userId: effectiveLeftUserId,
     annotationOverride: leftResizeController.previewAnnotation,
+    pendingAnnotations: allPendingAnnotations,
   });
 
   const {
@@ -105,9 +117,6 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
   });
 
   const codeMap = CodeHooks.useGetAllCodesMap();
-
-  // Fake annotation state for creating new annotations in left panel
-  const [fakeAnnotation, setFakeAnnotation] = useState<SpanAnnotationCreate | undefined>(undefined);
 
   const projectId = useAppSelector((state) => state.project.projectId) ?? -1;
 
@@ -261,7 +270,7 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
   );
 
   const handleLeftMouseUp = useCallback(
-    async (event: MouseEvent) => {
+    (event: MouseEvent) => {
       if (leftResizeController.shouldIgnoreMouseUp()) return;
       if (event.button === 2 || !leftTokenData || !isAnnotationAllowedLeft) return;
 
@@ -317,25 +326,8 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
         span_text: span_text,
       };
 
-      setFakeAnnotation(requestBody);
-
-      const affectedQueryKey = [QueryKey.SDOC_SPAN_ANNOTATIONS, requestBody.sdoc_id, effectiveLeftUserId];
-      await queryClient.cancelQueries({ queryKey: affectedQueryKey });
-
-      queryClient.setQueryData<SpanAnnotationRead[]>(affectedQueryKey, (old) => {
-        const spanAnnotation: SpanAnnotationRead = {
-          ...requestBody,
-          id: FAKE_ANNOTATION_ID,
-          text: requestBody.span_text,
-          code_id: requestBody.code_id,
-          created: "",
-          updated: "",
-          user_id: user?.id || SYSTEM_USER_ID,
-          group_ids: [],
-          memo_ids: [],
-        };
-        return old === undefined ? [spanAnnotation] : [...old, spanAnnotation];
-      });
+      // store the draft annotation in local state; it is rendered via the pendingAnnotations override
+      setDraftAnnotation(toPendingSpanAnnotation(requestBody, user?.id));
 
       const target = selectionStartElement;
       if (target) {
@@ -355,7 +347,6 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
       mostRecentCodeId,
       selectedCodeId,
       sdocData.id,
-      effectiveLeftUserId,
       handleLeftMenu,
       openSnackbar,
       leftResizeController,
@@ -383,26 +374,38 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
     });
   };
 
+  // send a create request and keep the annotation visible (pending) until the real one is cached.
+  // `pending` is the local preview annotation; only its create-payload fields are sent to the server.
+  const startCreate = (pending: SpanAnnotationRead, codeId: number, onSuccess?: () => void) => {
+    const requestBody: SpanAnnotationCreate = {
+      code_id: codeId,
+      sdoc_id: pending.sdoc_id,
+      begin: pending.begin,
+      end: pending.end,
+      begin_token: pending.begin_token,
+      end_token: pending.end_token,
+      span_text: pending.text,
+    };
+    setPendingAnnotations((prev) => [...prev, { ...pending, code_id: codeId }]);
+    createMutation.mutate(requestBody, {
+      onSuccess,
+      // remove the pending preview once the real annotation is in the cache (or the request failed)
+      onSettled: () => setPendingAnnotations((prev) => prev.filter((a) => a.id !== pending.id)),
+    });
+  };
+
   const handleLeftCodeSelectorAddCode = (codeId: number, isNewCode: boolean) => {
-    if (!fakeAnnotation) return;
-    createMutation.mutate(
-      {
-        ...fakeAnnotation,
-        code_id: codeId,
-      },
-      {
-        onSuccess: () => {
-          if (!isNewCode) {
-            dispatch(AnnoActions.moveCodeToTop(codeId));
-          }
-        },
-      },
-    );
+    if (!draftAnnotation) return;
+    startCreate(draftAnnotation, codeId, () => {
+      if (!isNewCode) {
+        dispatch(AnnoActions.moveCodeToTop(codeId));
+      }
+    });
   };
 
   const handleLeftCodeSelectorDuplicateAnnotation = (annotation: Annotation, codeId: number) => {
     if ("id" in annotation && "begin_token" in annotation && "end_token" in annotation) {
-      const fakeAnnotation: SpanAnnotationCreate = {
+      const requestBody: SpanAnnotationCreate = {
         begin: annotation.begin,
         end: annotation.end,
         begin_token: annotation.begin_token,
@@ -411,34 +414,20 @@ export const SpanAnnotationComparison = memo(({ sdocData, ...props }: SpanAnnota
         sdoc_id: annotation.sdoc_id,
         code_id: codeId,
       };
-      createMutation.mutate(fakeAnnotation, {
-        onSuccess: () => {
-          dispatch(AnnoActions.moveCodeToTop(codeId));
-        },
-      });
+      const pending = toPendingSpanAnnotation(requestBody, user?.id);
+      startCreate(pending, codeId, () => dispatch(AnnoActions.moveCodeToTop(codeId)));
     }
   };
 
   const handleLeftCodeSelectorClose = (reason?: "backdropClick" | "escapeKeyDown") => {
-    if (fakeAnnotation) {
+    if (draftAnnotation) {
       if (reason === "backdropClick") {
-        createMutation.mutate(
-          { ...fakeAnnotation },
-          {
-            onSuccess: () => {
-              dispatch(AnnoActions.moveCodeToTop(fakeAnnotation.code_id));
-            },
-          },
-        );
-      }
-      if (reason === "escapeKeyDown") {
-        queryClient.setQueryData<SpanAnnotationRead[]>(
-          [QueryKey.SDOC_SPAN_ANNOTATIONS, fakeAnnotation.sdoc_id, effectiveLeftUserId],
-          (old) => old?.filter((spanAnnotation) => spanAnnotation.id !== -1),
+        startCreate(draftAnnotation, draftAnnotation.code_id, () =>
+          dispatch(AnnoActions.moveCodeToTop(draftAnnotation.code_id)),
         );
       }
     }
-    setFakeAnnotation(undefined);
+    setDraftAnnotation(undefined);
   };
 
   const showBulkActions = isAnnotationAllowedLeft && effectiveRightUserId !== undefined;

--- a/frontend/src/features/annotation/_hooks/pendingBboxAnnotation.ts
+++ b/frontend/src/features/annotation/_hooks/pendingBboxAnnotation.ts
@@ -1,0 +1,29 @@
+import { BBoxAnnotationCreate } from "@models/BBoxAnnotationCreate";
+import { BBoxAnnotationRead } from "@models/BBoxAnnotationRead";
+import { SYSTEM_USER_ID } from "@utils/GlobalConstants";
+
+/**
+ * Pending (not yet persisted) bbox annotations are rendered from local state only — they are never
+ * written to the query cache and never sent to the server. Each one gets a unique NEGATIVE id so
+ * that several in-flight creations can be told apart and removed individually once saved.
+ * Any negative id simply means "pending" to the renderer (id < 0).
+ */
+let nextPendingId = -1;
+
+/**
+ * Wraps a create payload in a read-shaped shell so the renderer can draw a preview.
+ * Assigns a fresh unique negative id so concurrent pendings can be told apart.
+ */
+export function toPendingBboxAnnotation(
+  requestBody: BBoxAnnotationCreate,
+  userId: number | undefined,
+): BBoxAnnotationRead {
+  return {
+    ...requestBody,
+    id: nextPendingId--,
+    created: "",
+    updated: "",
+    user_id: userId || SYSTEM_USER_ID,
+    memo_ids: [],
+  };
+}

--- a/frontend/src/features/annotation/_hooks/pendingSentenceAnnotation.ts
+++ b/frontend/src/features/annotation/_hooks/pendingSentenceAnnotation.ts
@@ -1,0 +1,29 @@
+import { SentenceAnnotationCreate } from "@models/SentenceAnnotationCreate";
+import { SentenceAnnotationRead } from "@models/SentenceAnnotationRead";
+import { SYSTEM_USER_ID } from "@utils/GlobalConstants";
+
+/**
+ * Pending (not yet persisted) sentence annotations are rendered from local state only — they are never
+ * written to the query cache and never sent to the server. Each one gets a unique NEGATIVE id so
+ * that several in-flight creations can be told apart and removed individually once saved.
+ * Any negative id simply means "pending" to the renderer (id < 0).
+ */
+let nextPendingId = -1;
+
+/**
+ * Wraps a create payload in a read-shaped shell so the renderer can draw a preview.
+ * Assigns a fresh unique negative id so concurrent pendings can be told apart.
+ */
+export function toPendingSentenceAnnotation(
+  requestBody: SentenceAnnotationCreate,
+  userId: number | undefined,
+): SentenceAnnotationRead {
+  return {
+    ...requestBody,
+    id: nextPendingId--,
+    created: "",
+    updated: "",
+    user_id: userId || SYSTEM_USER_ID,
+    memo_ids: [],
+  };
+}

--- a/frontend/src/features/annotation/_hooks/pendingSpanAnnotation.ts
+++ b/frontend/src/features/annotation/_hooks/pendingSpanAnnotation.ts
@@ -1,0 +1,31 @@
+import { SpanAnnotationCreate } from "@models/SpanAnnotationCreate";
+import { SpanAnnotationRead } from "@models/SpanAnnotationRead";
+import { SYSTEM_USER_ID } from "@utils/GlobalConstants";
+
+/**
+ * Pending (not yet persisted) span annotations are rendered from local state only — they are never
+ * written to the query cache and never sent to the server. Each one gets a unique NEGATIVE id so
+ * that several in-flight creations can be told apart and removed individually once saved.
+ * Any negative id simply means "pending" to the renderer (id < 0).
+ */
+let nextPendingId = -1;
+
+/**
+ * Wraps a create payload in a read-shaped shell so the renderer can draw a preview.
+ * Assigns a fresh unique negative id so concurrent pendings can be told apart.
+ */
+export function toPendingSpanAnnotation(
+  requestBody: SpanAnnotationCreate,
+  userId: number | undefined,
+): SpanAnnotationRead {
+  return {
+    ...requestBody,
+    id: nextPendingId--,
+    text: requestBody.span_text,
+    created: "",
+    updated: "",
+    user_id: userId || SYSTEM_USER_ID,
+    group_ids: [],
+    memo_ids: [],
+  };
+}

--- a/frontend/src/features/annotation/_hooks/useComputeTokenData.ts
+++ b/frontend/src/features/annotation/_hooks/useComputeTokenData.ts
@@ -32,16 +32,20 @@ export function useTokenData(sdocData: SourceDocumentDataRead): IToken[] | undef
  * @param sdocData The source document data containing tokens and their character offsets.
  * @param userId The user whose span annotations should be loaded. The query remains disabled when no user ID is set.
  * @param annotationOverride An optional temporary annotation state used to render a live resize preview.
+ * @param pendingAnnotations Optional not-yet-persisted annotations (e.g. while the user picks a code, or
+ *   while a create mutation is in flight) that are rendered without being written to the query cache.
  * @returns Token metadata, a token-to-annotation-ID map, and an annotation-ID-to-annotation map.
  */
 export function useComputeTokenData({
   sdocData,
   userId,
   annotationOverride,
+  pendingAnnotations,
 }: {
   sdocData: SourceDocumentDataRead;
   userId: number | null | undefined;
   annotationOverride?: SpanAnnotationRead;
+  pendingAnnotations?: SpanAnnotationRead[];
 }) {
   // global server state (react query)
   const annotations = SpanAnnotationHooks.useGetSpanAnnotationsBatch(sdocData.id, userId);
@@ -57,8 +61,8 @@ export function useComputeTokenData({
     const spanGroupIdMapping = new Map<number, number>();
     const annotationMap = new Map<number, SpanAnnotationRead>();
     const annotationsPerToken = new Map<number, number[]>();
-    annotations.data.forEach((storedAnnotation) => {
-      const selectedAnnotation = storedAnnotation.id === annotationOverride?.id ? annotationOverride : storedAnnotation;
+
+    const addAnnotation = (selectedAnnotation: SpanAnnotationRead) => {
       const groupIds = selectedAnnotation.group_ids.map((id) => {
         let mapped = spanGroupIdMapping.get(id);
         if (mapped === undefined) {
@@ -78,9 +82,17 @@ export function useComputeTokenData({
         annotationsPerToken.set(i, tokenAnnotations);
       }
       annotationMap.set(annotation.id, annotation);
+    };
+
+    annotations.data.forEach((storedAnnotation) => {
+      addAnnotation(storedAnnotation.id === annotationOverride?.id ? annotationOverride : storedAnnotation);
+    });
+    // render pending (not yet persisted) annotations without touching the query cache
+    pendingAnnotations?.forEach((pendingAnnotation) => {
+      addAnnotation(pendingAnnotation);
     });
     return { annotationMap, annotationsPerToken };
-  }, [annotationOverride, annotations.data]);
+  }, [annotationOverride, pendingAnnotations, annotations.data]);
 
   return { tokenData, annotationsPerToken, annotationMap };
 }

--- a/frontend/src/features/annotation/_hooks/useComputeTokenData.ts
+++ b/frontend/src/features/annotation/_hooks/useComputeTokenData.ts
@@ -4,6 +4,16 @@ import { SpanAnnotationRead } from "@models/SpanAnnotationRead";
 import { useMemo } from "react";
 import { IToken } from "../_types/IToken";
 
+/**
+ * Derives token metadata from a source document's raw tokens and character offsets.
+ *
+ * Each token is enriched with its character boundaries, index, whitespace flag,
+ * and newline count. The result is memoized on `sdocData` and only recomputed
+ * when the document data changes.
+ *
+ * @param sdocData The source document data containing tokens and their character offsets.
+ * @returns The enriched token array, or `undefined` if no character offsets are available.
+ */
 export function useTokenData(sdocData: SourceDocumentDataRead): IToken[] | undefined {
   return useMemo(() => {
     if (!sdocData.token_character_offsets) return undefined;
@@ -47,16 +57,16 @@ export function useComputeTokenData({
   annotationOverride?: SpanAnnotationRead;
   pendingAnnotations?: SpanAnnotationRead[];
 }) {
-  // global server state (react query)
   const annotations = SpanAnnotationHooks.useGetSpanAnnotationsBatch(sdocData.id, userId);
-
-  // computed
-  // todo: maybe implement with selector?
   const tokenData = useTokenData(sdocData);
 
-  // annotationMap stores annotationId -> SpanAnnotationRead
-  // annotationsPerToken map stores tokenId -> spanAnnotationId[]
-  const { annotationMap, annotationsPerToken } = useMemo(() => {
+  // Three-layer memoization to avoid rebuilding the full maps on every mousemove during resize:
+  // 1. Base maps from server data (rare changes)
+  // 2. + pending annotations (rare changes, purely additive)
+  // 3. + annotation override (frequent during resize drag, targeted patch)
+
+  // Layer 1: base maps from server data only
+  const baseMaps = useMemo(() => {
     if (!annotations.data) return { annotationMap: undefined, annotationsPerToken: undefined };
     const spanGroupIdMapping = new Map<number, number>();
     const annotationMap = new Map<number, SpanAnnotationRead>();
@@ -84,15 +94,57 @@ export function useComputeTokenData({
       annotationMap.set(annotation.id, annotation);
     };
 
-    annotations.data.forEach((storedAnnotation) => {
-      addAnnotation(storedAnnotation.id === annotationOverride?.id ? annotationOverride : storedAnnotation);
-    });
-    // render pending (not yet persisted) annotations without touching the query cache
-    pendingAnnotations?.forEach((pendingAnnotation) => {
-      addAnnotation(pendingAnnotation);
+    annotations.data.forEach(addAnnotation);
+    return { annotationMap, annotationsPerToken };
+  }, [annotations.data]);
+
+  // Layer 2: patch pending annotations on top (purely additive, short-circuits when empty)
+  const withPendings = useMemo(() => {
+    if (!baseMaps.annotationMap || !baseMaps.annotationsPerToken) return baseMaps;
+    if (!pendingAnnotations || pendingAnnotations.length === 0) return baseMaps;
+
+    const annotationMap = new Map(baseMaps.annotationMap);
+    const annotationsPerToken = new Map(baseMaps.annotationsPerToken);
+
+    pendingAnnotations.forEach((pending) => {
+      annotationMap.set(pending.id, pending);
+      for (let i = pending.begin_token; i <= pending.end_token - 1; i++) {
+        const existing = annotationsPerToken.get(i) || [];
+        annotationsPerToken.set(i, [...existing, pending.id]);
+      }
     });
     return { annotationMap, annotationsPerToken };
-  }, [annotationOverride, pendingAnnotations, annotations.data]);
+  }, [baseMaps, pendingAnnotations]);
+
+  // Layer 3: patch the resize override on top (short-circuits when idle)
+  const { annotationMap, annotationsPerToken } = useMemo(() => {
+    if (!withPendings.annotationMap || !withPendings.annotationsPerToken) return withPendings;
+    if (!annotationOverride) return withPendings;
+
+    const original = withPendings.annotationMap.get(annotationOverride.id);
+    if (!original) return withPendings;
+
+    const annotationMap = new Map(withPendings.annotationMap);
+    const annotationsPerToken = new Map(withPendings.annotationsPerToken);
+
+    // remove old token entries
+    for (let i = original.begin_token; i <= original.end_token - 1; i++) {
+      const existing = annotationsPerToken.get(i);
+      if (existing) {
+        annotationsPerToken.set(
+          i,
+          existing.filter((id) => id !== original.id),
+        );
+      }
+    }
+    // add new token entries
+    for (let i = annotationOverride.begin_token; i <= annotationOverride.end_token - 1; i++) {
+      const existing = annotationsPerToken.get(i) || [];
+      annotationsPerToken.set(i, [...existing, annotationOverride.id]);
+    }
+    annotationMap.set(annotationOverride.id, annotationOverride);
+    return { annotationMap, annotationsPerToken };
+  }, [withPendings, annotationOverride]);
 
   return { tokenData, annotationsPerToken, annotationMap };
 }


### PR DESCRIPTION
Fix stuck fake annotations & eliminate cache-based optimistic creates

Problem: Span annotation creation used an optimistic fake annotation (id -1) written directly into the React Query cache. Under concurrent invalidations, the fake→real id swap could be clobbered, leaving a permanently stuck fake annotation that broke edit/rename/delete/memo actions.

Solution: Pending annotations are now kept in component-local state only — never written to the query cache. They are rendered via a [pendingAnnotations] parameter in [useComputeTokenData], following the same pattern as the existing resize [annotationOverride].